### PR TITLE
Suppress Warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,14 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <compilerArgument>-proc:full</compilerArgument>
+                </configuration>
+            </plugin>
+            
+            <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>


### PR DESCRIPTION
Closes #1

<img width="812" alt="Screenshot 2024-11-19 at 3 09 52 PM" src="https://github.com/user-attachments/assets/01fc2ca1-b6b5-465e-bc91-4ec52bb7d350">

Warning produced when running mvn clean compile. After adding the maven-compiler-plugin the warning does not appear.

