### PR TITLE
Implemented getActiveQuarterList method

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBAPIQuarterController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBAPIQuarterController.java
@@ -5,8 +5,8 @@ import edu.ucsb.cs156.courses.repositories.UserRepository;
 import edu.ucsb.cs156.courses.services.UCSBAPIQuarterService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
 import java.util.ArrayList;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -33,8 +33,8 @@ public class UCSBAPIQuarterController extends ApiController {
   @Operation(summary = "Get active quarters between start and end quarters")
   @GetMapping(value = "/activeQuarters", produces = "application/json")
   public ArrayList<String> getActiveQuarters() throws Exception {
-      return ucsbAPIQuarterService.getActiveQuarterList();
-  }  
+    return ucsbAPIQuarterService.getActiveQuarterList();
+  }
 
   @Operation(summary = "Get dates for all quarters")
   @GetMapping(value = "/allQuarters", produces = "application/json")

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBAPIQuarterController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBAPIQuarterController.java
@@ -6,6 +6,7 @@ import edu.ucsb.cs156.courses.services.UCSBAPIQuarterService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
+import java.util.ArrayList;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -28,6 +29,12 @@ public class UCSBAPIQuarterController extends ApiController {
   public UCSBAPIQuarter getCurrentQuarter() throws Exception {
     return ucsbAPIQuarterService.getCurrentQuarter();
   }
+
+  @Operation(summary = "Get active quarters between start and end quarters")
+  @GetMapping(value = "/activeQuarters", produces = "application/json")
+  public ArrayList<String> getActiveQuarters() throws Exception {
+      return ucsbAPIQuarterService.getActiveQuarterList();
+  }  
 
   @Operation(summary = "Get dates for all quarters")
   @GetMapping(value = "/allQuarters", produces = "application/json")

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBAPIQuarterController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBAPIQuarterController.java
@@ -5,7 +5,6 @@ import edu.ucsb.cs156.courses.repositories.UserRepository;
 import edu.ucsb.cs156.courses.services.UCSBAPIQuarterService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,7 +31,7 @@ public class UCSBAPIQuarterController extends ApiController {
 
   @Operation(summary = "Get active quarters between start and end quarters")
   @GetMapping(value = "/activeQuarters", produces = "application/json")
-  public ArrayList<String> getActiveQuarters() throws Exception {
+  public List<String> activeQuarters() throws Exception {
     return ucsbAPIQuarterService.getActiveQuarterList();
   }
 

--- a/src/main/java/edu/ucsb/cs156/courses/services/UCSBAPIQuarterService.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/UCSBAPIQuarterService.java
@@ -161,8 +161,8 @@ public class UCSBAPIQuarterService {
     return savedQuarters;
   }
 
-  public ArrayList<String> getActiveQuarterList() throws Exception {
-    ArrayList<String> activeQuarters = new ArrayList<>();
+  public List<String> getActiveQuarterList() throws Exception {
+    List<String> activeQuarters = new ArrayList<>();
     String startQuarter = getCurrentQuarterYYYYQ();
     String endQuarter = getEndQtrYYYYQ();
 

--- a/src/main/java/edu/ucsb/cs156/courses/services/UCSBAPIQuarterService.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/UCSBAPIQuarterService.java
@@ -51,6 +51,9 @@ public class UCSBAPIQuarterService {
   public static final String ALL_QUARTERS_ENDPOINT =
       "https://api.ucsb.edu/academics/quartercalendar/v1/quarters";
 
+  public static final String END_QUARTER_ENDPOINT =
+      "https://api.ucsb.edu/academics/quartercalendar/v1/quarters/end";
+
   public String getStartQtrYYYYQ() {
     return startQtrYYYYQ;
   }
@@ -166,11 +169,9 @@ public class UCSBAPIQuarterService {
     List<Quarter> quarterObjects = Quarter.quarterList(startQuarter, endQuarter);
 
     for (Quarter quarter : quarterObjects) {
-        activeQuarters.add(quarter.getYYYYQ());
+      activeQuarters.add(quarter.getYYYYQ());
     }
 
     return activeQuarters;
-}
-
-
+  }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/services/UCSBAPIQuarterService.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/UCSBAPIQuarterService.java
@@ -3,6 +3,7 @@ package edu.ucsb.cs156.courses.services;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.courses.entities.UCSBAPIQuarter;
+import edu.ucsb.cs156.courses.models.Quarter;
 import edu.ucsb.cs156.courses.repositories.UCSBAPIQuarterRepository;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -156,4 +157,20 @@ public class UCSBAPIQuarterService {
     log.info("savedQuarters.size={}", savedQuarters.size());
     return savedQuarters;
   }
+
+  public ArrayList<String> getActiveQuarterList() throws Exception {
+    ArrayList<String> activeQuarters = new ArrayList<>();
+    String startQuarter = getCurrentQuarterYYYYQ();
+    String endQuarter = getEndQtrYYYYQ();
+
+    List<Quarter> quarterObjects = Quarter.quarterList(startQuarter, endQuarter);
+
+    for (Quarter quarter : quarterObjects) {
+        activeQuarters.add(quarter.getYYYYQ());
+    }
+
+    return activeQuarters;
+}
+
+
 }

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBAPIQuarterControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBAPIQuarterControllerTests.java
@@ -112,24 +112,22 @@ public class UCSBAPIQuarterControllerTests extends ControllerTestCase {
             new TypeReference<List<UCSBAPIQuarter>>() {}));
   }
 
-  // @Test
-  // public void test_specificQuarter() throws Exception {
-  //   UCSBAPIQuarter sampleQuarter =
-  //       objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M24, UCSBAPIQuarter.class);
-  //   String quarter = "20224";
-  //   String url = "/api/public/specificQuarter?quarter=" + quarter;
+  @Test
+  public void test_activeQuarters() throws Exception {
 
-  //   when(ucsbAPIQuarterService.getQuarter(quarter)).thenReturn(sampleQuarter);
+    String url = "/api/public/activeQuarters";
+    List<String> activeQuarters = List.of("20243");
+    when(ucsbAPIQuarterService.getActiveQuarterList()).thenReturn(activeQuarters);
 
-  //   MvcResult response =
-  //       mockMvc
-  //           .perform(get(url).contentType("application/json"))
-  //           .andExpect(status().isOk())
-  //           .andReturn();
+    MvcResult response =
+        mockMvc
+            .perform(get(url).contentType("application/json"))
+            .andExpect(status().isOk())
+            .andReturn();
 
-  //   assertEquals(
-  //       sampleQuarter,
-  //       objectMapper.readValue(response.getResponse().getContentAsString(),
-  // UCSBAPIQuarter.class));
-  // }
+    assertEquals(
+        activeQuarters,
+        objectMapper.readValue(
+            response.getResponse().getContentAsString(), new TypeReference<List<String>>() {}));
+  }
 }

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBAPIQuarterControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBAPIQuarterControllerTests.java
@@ -111,4 +111,31 @@ public class UCSBAPIQuarterControllerTests extends ControllerTestCase {
             response.getResponse().getContentAsString(),
             new TypeReference<List<UCSBAPIQuarter>>() {}));
   }
+
+@Test   
+public void test_getActiveQuarters() throws Exception {
+    // Arrange: Define the expected result
+    ArrayList<String> expectedResult = new ArrayList<>();
+    expectedResult.add("20244");
+    expectedResult.add("20251");
+
+    String url = "/api/public/activeQuarters";
+
+    // Mock the service method
+    when(ucsbAPIQuarterService.getActiveQuarterList()).thenReturn(expectedResult);
+
+    // Act: Call the endpoint
+    MvcResult response =
+        mockMvc
+            .perform(get(url).contentType("application/json"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // Assert: Compare the actual and expected results
+    assertEquals(
+        objectMapper.writeValueAsString(expectedResult), // Convert expectedResult to JSON string
+        response.getResponse().getContentAsString() // Get actual JSON response from endpoint
+    );
+}
+
 }

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBAPIQuarterControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBAPIQuarterControllerTests.java
@@ -112,30 +112,24 @@ public class UCSBAPIQuarterControllerTests extends ControllerTestCase {
             new TypeReference<List<UCSBAPIQuarter>>() {}));
   }
 
-@Test   
-public void test_getActiveQuarters() throws Exception {
-    // Arrange: Define the expected result
-    ArrayList<String> expectedResult = new ArrayList<>();
-    expectedResult.add("20244");
-    expectedResult.add("20251");
+  // @Test
+  // public void test_specificQuarter() throws Exception {
+  //   UCSBAPIQuarter sampleQuarter =
+  //       objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M24, UCSBAPIQuarter.class);
+  //   String quarter = "20224";
+  //   String url = "/api/public/specificQuarter?quarter=" + quarter;
 
-    String url = "/api/public/activeQuarters";
+  //   when(ucsbAPIQuarterService.getQuarter(quarter)).thenReturn(sampleQuarter);
 
-    // Mock the service method
-    when(ucsbAPIQuarterService.getActiveQuarterList()).thenReturn(expectedResult);
+  //   MvcResult response =
+  //       mockMvc
+  //           .perform(get(url).contentType("application/json"))
+  //           .andExpect(status().isOk())
+  //           .andReturn();
 
-    // Act: Call the endpoint
-    MvcResult response =
-        mockMvc
-            .perform(get(url).contentType("application/json"))
-            .andExpect(status().isOk())
-            .andReturn();
-
-    // Assert: Compare the actual and expected results
-    assertEquals(
-        objectMapper.writeValueAsString(expectedResult), // Convert expectedResult to JSON string
-        response.getResponse().getContentAsString() // Get actual JSON response from endpoint
-    );
-}
-
+  //   assertEquals(
+  //       sampleQuarter,
+  //       objectMapper.readValue(response.getResponse().getContentAsString(),
+  // UCSBAPIQuarter.class));
+  // }
 }

--- a/src/test/java/edu/ucsb/cs156/courses/services/UCSBAPIQuarterServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/services/UCSBAPIQuarterServiceTests.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.courses.entities.UCSBAPIQuarter;
+import edu.ucsb.cs156.courses.models.Quarter;
 import edu.ucsb.cs156.courses.repositories.UCSBAPIQuarterRepository;
 import java.util.ArrayList;
 import java.util.List;
@@ -175,6 +176,33 @@ public class UCSBAPIQuarterServiceTests {
 
     assertEquals(expectedResult, actualResult);
   }
+  @Test
+  public void test_getActiveQuarterList() throws Exception {
+      // Arrange: Mock start and end quarters
+      String startQuarter = "20244";
+      String endQuarter = "20251";
+
+      List<Quarter> mockQuarterList = new ArrayList<>();
+      mockQuarterList.add(new Quarter("20244"));
+      mockQuarterList.add(new Quarter("20245"));
+      mockQuarterList.add(new Quarter("20251"));
+
+      // Mock dependencies
+      when(service.getCurrentQuarterYYYYQ()).thenReturn(startQuarter);
+      when(service.getEndQtrYYYYQ()).thenReturn(endQuarter);
+      when(Quarter.quarterList(startQuarter, endQuarter)).thenReturn(mockQuarterList);
+
+      // Act: Call the service method
+      ArrayList<String> result = service.getActiveQuarterList();
+
+      // Assert: Verify the result matches expected values
+      ArrayList<String> expected = new ArrayList<>();
+      expected.add("20244");
+      expected.add("20245");
+      expected.add("20251");
+
+      assertEquals(expected, result);
+  }
 
   @Test
   public void test_quarterYYYYQInRange_20211_true() {
@@ -188,7 +216,7 @@ public class UCSBAPIQuarterServiceTests {
 
   @Test
   public void test_quarterYYYYQInRange_20222_true() {
-    assertEquals(true, service.quarterYYYYQInRange("20222"));
+      assertEquals(true, service.quarterYYYYQInRange("20222"));
   }
 
   @Test
@@ -210,4 +238,6 @@ public class UCSBAPIQuarterServiceTests {
   public void test_quarterYYYYQInRange_20231_false() {
     assertEquals(false, service.quarterYYYYQInRange("20231"));
   }
+  
+
 }


### PR DESCRIPTION
Closes #6

Added a method to return ArrayList<String> to list YYYYQ codes from current quarter and ending with current value returned by getEndQtrYYYYQ. This method is called from the endpoint /api/public/activeQuarters defined in the UCSBAPIQuarterController

Test [here](https://courses-christopherchau.dokku-03.cs.ucsb.edu/)