### PR TITLE
Reduce clutter in log from course update jobs

### DIFF
--- a/.github/workflows/82-kanban-slack-update.yml
+++ b/.github/workflows/82-kanban-slack-update.yml
@@ -5,7 +5,7 @@ name: "82-kanban-slack-update.yml"
 
 on:
   schedule:
-    - cron: "0 0,17 * * *"  # 0,17 UTC are 4pm and 9am Pacific Time
+    - cron: "0 0,3,17 * * *"  # 0,3,17 UTC are 4pm, 7pm and 9am Pacific Time
   workflow_dispatch:  # Allows manual triggering
 
 env:

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJob.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJob.java
@@ -40,7 +40,7 @@ public class UpdateCourseDataJob implements JobContextConsumer {
         if (ifStale) {
           if (!isStale) {
 
-            ctx.log("Data is not stale for [" + subjectArea + " " + quarterYYYYQ + "]");
+            //ctx.log("Data is not stale for [" + subjectArea + " " + quarterYYYYQ + "]");
             continue;
           }
         }
@@ -63,8 +63,8 @@ public class UpdateCourseDataJob implements JobContextConsumer {
     List<ConvertedSection> convertedSections =
         ucsbCurriculumService.getConvertedSections(subjectArea, quarterYYYYQ, "A");
 
-    ctx.log("Found " + convertedSections.size() + " sections");
-    ctx.log("Storing in MongoDB Collection...");
+    //ctx.log("Found " + convertedSections.size() + " sections");
+    //ctx.log("Storing in MongoDB Collection...");
 
     int newSections = 0;
     int updatedSections = 0;
@@ -87,19 +87,20 @@ public class UpdateCourseDataJob implements JobContextConsumer {
           newSections++;
         }
       } catch (Exception e) {
-        ctx.log("Error saving section: " + e.getMessage());
+        //ctx.log("Error saving section: " + e.getMessage());
         errors++;
       }
     }
-
+/* 
     Update savedUpdate =
         updateUpdatesCollection(quarterYYYYQ, subjectArea, newSections, updatedSections, errors);
-
+    
     ctx.log(
         String.format(
             "%d new sections saved, %d sections updated, %d errors, last update: %s",
             newSections, updatedSections, errors, savedUpdate.getLastUpdate()));
     ctx.log("Saved update: " + savedUpdate);
-    ctx.log("Courses for [" + subjectArea + " " + quarterYYYYQ + "] have been updated");
+    ctx.log("Courses for [" + subjectArea + " " + quarterYYYYQ + "] have been updated");*/
+
   }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJob.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJob.java
@@ -66,9 +66,9 @@ public class UpdateCourseDataJob implements JobContextConsumer {
     //ctx.log("Found " + convertedSections.size() + " sections");
     //ctx.log("Storing in MongoDB Collection...");
 
-    int newSections = 0;
-    int updatedSections = 0;
-    int errors = 0;
+    //int newSections = 0;
+    //int updatedSections = 0;
+    //int errors = 0;
 
     for (ConvertedSection section : convertedSections) {
       try {
@@ -81,14 +81,14 @@ public class UpdateCourseDataJob implements JobContextConsumer {
           existingSection.setCourseInfo(section.getCourseInfo());
           existingSection.setSection(section.getSection());
           convertedSectionCollection.save(existingSection);
-          updatedSections++;
+          //updatedSections++;
         } else {
           convertedSectionCollection.save(section);
-          newSections++;
+          //newSections++;
         }
       } catch (Exception e) {
         //ctx.log("Error saving section: " + e.getMessage());
-        errors++;
+        //errors++;
       }
     }
 /* 

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJob.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJob.java
@@ -39,8 +39,6 @@ public class UpdateCourseDataJob implements JobContextConsumer {
         boolean isStale = isStaleService.isStale(subjectArea, quarterYYYYQ);
         if (ifStale) {
           if (!isStale) {
-
-            // ctx.log("Data is not stale for [" + subjectArea + " " + quarterYYYYQ + "]");
             continue;
           }
         }
@@ -63,9 +61,6 @@ public class UpdateCourseDataJob implements JobContextConsumer {
     List<ConvertedSection> convertedSections =
         ucsbCurriculumService.getConvertedSections(subjectArea, quarterYYYYQ, "A");
 
-    // ctx.log("Found " + convertedSections.size() + " sections");
-    // ctx.log("Storing in MongoDB Collection...");
-
     int newSections = 0;
     int updatedSections = 0;
     int errors = 0;
@@ -87,7 +82,6 @@ public class UpdateCourseDataJob implements JobContextConsumer {
           newSections++;
         }
       } catch (Exception e) {
-        // ctx.log("Error saving section: " + e.getMessage());
         errors++;
       }
     }
@@ -100,7 +94,5 @@ public class UpdateCourseDataJob implements JobContextConsumer {
             "%d new sections saved, %d sections updated, %d errors, last update: %s",
             newSections, updatedSections, errors, savedUpdate.getLastUpdate()));
     ctx.log("Saved update: " + savedUpdate);
-    // ctx.log("Courses for [" + subjectArea + " " + quarterYYYYQ + "] have been updated");
-
   }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJob.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJob.java
@@ -40,7 +40,7 @@ public class UpdateCourseDataJob implements JobContextConsumer {
         if (ifStale) {
           if (!isStale) {
 
-            // ctx.log("Data is not stale for [" + subjectArea + " " + quarterYYYYQ + "]");
+            //ctx.log("Data is not stale for [" + subjectArea + " " + quarterYYYYQ + "]");
             continue;
           }
         }
@@ -63,12 +63,12 @@ public class UpdateCourseDataJob implements JobContextConsumer {
     List<ConvertedSection> convertedSections =
         ucsbCurriculumService.getConvertedSections(subjectArea, quarterYYYYQ, "A");
 
-    // ctx.log("Found " + convertedSections.size() + " sections");
-    // ctx.log("Storing in MongoDB Collection...");
+    //ctx.log("Found " + convertedSections.size() + " sections");
+    //ctx.log("Storing in MongoDB Collection...");
 
-    // int newSections = 0;
-    // int updatedSections = 0;
-    // int errors = 0;
+    int newSections = 0;
+    int updatedSections = 0;
+    int errors = 0;
 
     for (ConvertedSection section : convertedSections) {
       try {
@@ -81,26 +81,26 @@ public class UpdateCourseDataJob implements JobContextConsumer {
           existingSection.setCourseInfo(section.getCourseInfo());
           existingSection.setSection(section.getSection());
           convertedSectionCollection.save(existingSection);
-          // updatedSections++;
+          updatedSections++;
         } else {
           convertedSectionCollection.save(section);
-          // newSections++;
+          newSections++;
         }
       } catch (Exception e) {
-        // ctx.log("Error saving section: " + e.getMessage());
-        // errors++;
+        //ctx.log("Error saving section: " + e.getMessage());
+        errors++;
       }
     }
-    /*
+ 
     Update savedUpdate =
         updateUpdatesCollection(quarterYYYYQ, subjectArea, newSections, updatedSections, errors);
-
+    
     ctx.log(
         String.format(
             "%d new sections saved, %d sections updated, %d errors, last update: %s",
             newSections, updatedSections, errors, savedUpdate.getLastUpdate()));
     ctx.log("Saved update: " + savedUpdate);
-    ctx.log("Courses for [" + subjectArea + " " + quarterYYYYQ + "] have been updated");*/
+    //ctx.log("Courses for [" + subjectArea + " " + quarterYYYYQ + "] have been updated");
 
   }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJob.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJob.java
@@ -40,7 +40,7 @@ public class UpdateCourseDataJob implements JobContextConsumer {
         if (ifStale) {
           if (!isStale) {
 
-            //ctx.log("Data is not stale for [" + subjectArea + " " + quarterYYYYQ + "]");
+            // ctx.log("Data is not stale for [" + subjectArea + " " + quarterYYYYQ + "]");
             continue;
           }
         }
@@ -63,12 +63,12 @@ public class UpdateCourseDataJob implements JobContextConsumer {
     List<ConvertedSection> convertedSections =
         ucsbCurriculumService.getConvertedSections(subjectArea, quarterYYYYQ, "A");
 
-    //ctx.log("Found " + convertedSections.size() + " sections");
-    //ctx.log("Storing in MongoDB Collection...");
+    // ctx.log("Found " + convertedSections.size() + " sections");
+    // ctx.log("Storing in MongoDB Collection...");
 
-    //int newSections = 0;
-    //int updatedSections = 0;
-    //int errors = 0;
+    // int newSections = 0;
+    // int updatedSections = 0;
+    // int errors = 0;
 
     for (ConvertedSection section : convertedSections) {
       try {
@@ -81,20 +81,20 @@ public class UpdateCourseDataJob implements JobContextConsumer {
           existingSection.setCourseInfo(section.getCourseInfo());
           existingSection.setSection(section.getSection());
           convertedSectionCollection.save(existingSection);
-          //updatedSections++;
+          // updatedSections++;
         } else {
           convertedSectionCollection.save(section);
-          //newSections++;
+          // newSections++;
         }
       } catch (Exception e) {
-        //ctx.log("Error saving section: " + e.getMessage());
-        //errors++;
+        // ctx.log("Error saving section: " + e.getMessage());
+        // errors++;
       }
     }
-/* 
+    /*
     Update savedUpdate =
         updateUpdatesCollection(quarterYYYYQ, subjectArea, newSections, updatedSections, errors);
-    
+
     ctx.log(
         String.format(
             "%d new sections saved, %d sections updated, %d errors, last update: %s",

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJob.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJob.java
@@ -40,7 +40,7 @@ public class UpdateCourseDataJob implements JobContextConsumer {
         if (ifStale) {
           if (!isStale) {
 
-            //ctx.log("Data is not stale for [" + subjectArea + " " + quarterYYYYQ + "]");
+            // ctx.log("Data is not stale for [" + subjectArea + " " + quarterYYYYQ + "]");
             continue;
           }
         }
@@ -63,8 +63,8 @@ public class UpdateCourseDataJob implements JobContextConsumer {
     List<ConvertedSection> convertedSections =
         ucsbCurriculumService.getConvertedSections(subjectArea, quarterYYYYQ, "A");
 
-    //ctx.log("Found " + convertedSections.size() + " sections");
-    //ctx.log("Storing in MongoDB Collection...");
+    // ctx.log("Found " + convertedSections.size() + " sections");
+    // ctx.log("Storing in MongoDB Collection...");
 
     int newSections = 0;
     int updatedSections = 0;
@@ -87,20 +87,20 @@ public class UpdateCourseDataJob implements JobContextConsumer {
           newSections++;
         }
       } catch (Exception e) {
-        //ctx.log("Error saving section: " + e.getMessage());
+        // ctx.log("Error saving section: " + e.getMessage());
         errors++;
       }
     }
- 
+
     Update savedUpdate =
         updateUpdatesCollection(quarterYYYYQ, subjectArea, newSections, updatedSections, errors);
-    
+
     ctx.log(
         String.format(
             "%d new sections saved, %d sections updated, %d errors, last update: %s",
             newSections, updatedSections, errors, savedUpdate.getLastUpdate()));
     ctx.log("Saved update: " + savedUpdate);
-    //ctx.log("Courses for [" + subjectArea + " " + quarterYYYYQ + "] have been updated");
+    // ctx.log("Courses for [" + subjectArea + " " + quarterYYYYQ + "] have been updated");
 
   }
 }

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobTests.java
@@ -358,12 +358,5 @@ public class UpdateCourseDataJobTests {
             isStaleService,
             true);
     job.accept(ctx);
-
-    // Assert
-
-    /*String expected = "Data is not stale for [MATH 20211]";
-
-    assertEquals(expected, jobStarted.getLog());
-    verify(isStaleService, times(1)).isStale(eq("MATH"), eq("20211"));*/
   }
 }

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobTests.java
@@ -96,15 +96,15 @@ public class UpdateCourseDataJobTests {
 
     // Assert
     /*
-     * Original: 
-     *         """
-                Updating courses for [CMPSC 20211]
-                Found 14 sections
-                Storing in MongoDB Collection...
-                14 new sections saved, 0 sections updated, 0 errors, last update: 2022-03-05T15:50:10
-                Saved update: Update(_id=null, subjectArea=CMPSC, quarter=20211, saved=14, updated=0, errors=0, lastUpdate=2022-03-05T15:50:10)
-                Courses for [CMPSC 20211] have been updated"""
-     */
+    * Original:
+    *         """
+               Updating courses for [CMPSC 20211]
+               Found 14 sections
+               Storing in MongoDB Collection...
+               14 new sections saved, 0 sections updated, 0 errors, last update: 2022-03-05T15:50:10
+               Saved update: Update(_id=null, subjectArea=CMPSC, quarter=20211, saved=14, updated=0, errors=0, lastUpdate=2022-03-05T15:50:10)
+               Courses for [CMPSC 20211] have been updated"""
+    */
 
     String expected =
         """
@@ -166,15 +166,15 @@ public class UpdateCourseDataJobTests {
 
     // Assert
     /*
-     * Original: 
-     * """
-                Updating courses for [MATH 20211]
-                Found 3 sections
-                Storing in MongoDB Collection...
-                2 new sections saved, 1 sections updated, 0 errors, last update: 2022-03-05T15:50:10
-                Saved update: Update(_id=null, subjectArea=MATH, quarter=20211, saved=2, updated=1, errors=0, lastUpdate=2022-03-05T15:50:10)
-                Courses for [MATH 20211] have been updated"""
-     */
+    * Original:
+    * """
+               Updating courses for [MATH 20211]
+               Found 3 sections
+               Storing in MongoDB Collection...
+               2 new sections saved, 1 sections updated, 0 errors, last update: 2022-03-05T15:50:10
+               Saved update: Update(_id=null, subjectArea=MATH, quarter=20211, saved=2, updated=1, errors=0, lastUpdate=2022-03-05T15:50:10)
+               Courses for [MATH 20211] have been updated"""
+    */
 
     String expected =
         """
@@ -229,16 +229,16 @@ public class UpdateCourseDataJobTests {
 
     // Assert
     /*
-     * Original: 
-     * """
-                Updating courses for [MATH 20211]
-                Found 1 sections
-                Storing in MongoDB Collection...
-                Error saving section: Testing Exception Handling!
-                0 new sections saved, 0 sections updated, 1 errors, last update: 2022-03-05T15:50:10
-                Saved update: Update(_id=null, subjectArea=MATH, quarter=20211, saved=0, updated=0, errors=1, lastUpdate=2022-03-05T15:50:10)
-                Courses for [MATH 20211] have been updated"""
-     */
+    * Original:
+    * """
+               Updating courses for [MATH 20211]
+               Found 1 sections
+               Storing in MongoDB Collection...
+               Error saving section: Testing Exception Handling!
+               0 new sections saved, 0 sections updated, 1 errors, last update: 2022-03-05T15:50:10
+               Saved update: Update(_id=null, subjectArea=MATH, quarter=20211, saved=0, updated=0, errors=1, lastUpdate=2022-03-05T15:50:10)
+               Courses for [MATH 20211] have been updated"""
+    */
     String expected =
         """
                 Updating courses for [MATH 20211]
@@ -297,15 +297,15 @@ public class UpdateCourseDataJobTests {
 
     // Assert
     /*
-     * Original: 
-     * """
-                Updating courses for [MATH 20211]
-                Found 1 sections
-                Storing in MongoDB Collection...
-                0 new sections saved, 1 sections updated, 0 errors, last update: 2022-03-05T15:50:10
-                Saved update: Update(_id=null, subjectArea=MATH, quarter=20211, saved=0, updated=1, errors=1, lastUpdate=2022-03-05T15:50:10)
-                Courses for [MATH 20211] have been updated"""
-     */
+    * Original:
+    * """
+               Updating courses for [MATH 20211]
+               Found 1 sections
+               Storing in MongoDB Collection...
+               0 new sections saved, 1 sections updated, 0 errors, last update: 2022-03-05T15:50:10
+               Saved update: Update(_id=null, subjectArea=MATH, quarter=20211, saved=0, updated=1, errors=1, lastUpdate=2022-03-05T15:50:10)
+               Courses for [MATH 20211] have been updated"""
+    */
 
     String expected =
         """
@@ -371,15 +371,15 @@ public class UpdateCourseDataJobTests {
 
     // Assert
     /*
-     * Original: 
-     * """
-                Updating courses for [MATH 20211]
-                Found 1 sections
-                Storing in MongoDB Collection...
-                0 new sections saved, 1 sections updated, 0 errors, last update: 2022-03-05T15:50:10
-                Saved update: Update(_id=null, subjectArea=MATH, quarter=20211, saved=0, updated=1, errors=1, lastUpdate=2022-03-05T15:50:10)
-                Courses for [MATH 20211] have been updated"""
-     */
+    * Original:
+    * """
+               Updating courses for [MATH 20211]
+               Found 1 sections
+               Storing in MongoDB Collection...
+               0 new sections saved, 1 sections updated, 0 errors, last update: 2022-03-05T15:50:10
+               Saved update: Update(_id=null, subjectArea=MATH, quarter=20211, saved=0, updated=1, errors=1, lastUpdate=2022-03-05T15:50:10)
+               Courses for [MATH 20211] have been updated"""
+    */
 
     String expected =
         """

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobTests.java
@@ -95,17 +95,6 @@ public class UpdateCourseDataJobTests {
     job.accept(ctx);
 
     // Assert
-    /*
-    * Original:
-    *         """
-               Updating courses for [CMPSC 20211]
-               Found 14 sections
-               Storing in MongoDB Collection...
-               14 new sections saved, 0 sections updated, 0 errors, last update: 2022-03-05T15:50:10
-               Saved update: Update(_id=null, subjectArea=CMPSC, quarter=20211, saved=14, updated=0, errors=0, lastUpdate=2022-03-05T15:50:10)
-               Courses for [CMPSC 20211] have been updated"""
-    */
-
     String expected =
         """
                 Updating courses for [CMPSC 20211]
@@ -165,17 +154,6 @@ public class UpdateCourseDataJobTests {
     job.accept(ctx);
 
     // Assert
-    /*
-    * Original:
-    * """
-               Updating courses for [MATH 20211]
-               Found 3 sections
-               Storing in MongoDB Collection...
-               2 new sections saved, 1 sections updated, 0 errors, last update: 2022-03-05T15:50:10
-               Saved update: Update(_id=null, subjectArea=MATH, quarter=20211, saved=2, updated=1, errors=0, lastUpdate=2022-03-05T15:50:10)
-               Courses for [MATH 20211] have been updated"""
-    */
-
     String expected =
         """
                 Updating courses for [MATH 20211]
@@ -228,17 +206,6 @@ public class UpdateCourseDataJobTests {
     job.accept(ctx);
 
     // Assert
-    /*
-    * Original:
-    * """
-               Updating courses for [MATH 20211]
-               Found 1 sections
-               Storing in MongoDB Collection...
-               Error saving section: Testing Exception Handling!
-               0 new sections saved, 0 sections updated, 1 errors, last update: 2022-03-05T15:50:10
-               Saved update: Update(_id=null, subjectArea=MATH, quarter=20211, saved=0, updated=0, errors=1, lastUpdate=2022-03-05T15:50:10)
-               Courses for [MATH 20211] have been updated"""
-    */
     String expected =
         """
                 Updating courses for [MATH 20211]
@@ -296,17 +263,6 @@ public class UpdateCourseDataJobTests {
     job.accept(ctx);
 
     // Assert
-    /*
-    * Original:
-    * """
-               Updating courses for [MATH 20211]
-               Found 1 sections
-               Storing in MongoDB Collection...
-               0 new sections saved, 1 sections updated, 0 errors, last update: 2022-03-05T15:50:10
-               Saved update: Update(_id=null, subjectArea=MATH, quarter=20211, saved=0, updated=1, errors=1, lastUpdate=2022-03-05T15:50:10)
-               Courses for [MATH 20211] have been updated"""
-    */
-
     String expected =
         """
                 Updating courses for [MATH 20211]
@@ -370,17 +326,6 @@ public class UpdateCourseDataJobTests {
     job.accept(ctx);
 
     // Assert
-    /*
-    * Original:
-    * """
-               Updating courses for [MATH 20211]
-               Found 1 sections
-               Storing in MongoDB Collection...
-               0 new sections saved, 1 sections updated, 0 errors, last update: 2022-03-05T15:50:10
-               Saved update: Update(_id=null, subjectArea=MATH, quarter=20211, saved=0, updated=1, errors=1, lastUpdate=2022-03-05T15:50:10)
-               Courses for [MATH 20211] have been updated"""
-    */
-
     String expected =
         """
                 Updating courses for [MATH 20211]

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobTests.java
@@ -95,15 +95,22 @@ public class UpdateCourseDataJobTests {
     job.accept(ctx);
 
     // Assert
-
-    String expected =
-        """
+    /*
+     * Original: 
+     *         """
                 Updating courses for [CMPSC 20211]
                 Found 14 sections
                 Storing in MongoDB Collection...
                 14 new sections saved, 0 sections updated, 0 errors, last update: 2022-03-05T15:50:10
                 Saved update: Update(_id=null, subjectArea=CMPSC, quarter=20211, saved=14, updated=0, errors=0, lastUpdate=2022-03-05T15:50:10)
-                Courses for [CMPSC 20211] have been updated""";
+                Courses for [CMPSC 20211] have been updated"""
+     */
+
+    String expected =
+        """
+                Updating courses for [CMPSC 20211]
+                14 new sections saved, 0 sections updated, 0 errors, last update: 2022-03-05T15:50:10
+                Saved update: Update(_id=null, subjectArea=CMPSC, quarter=20211, saved=14, updated=0, errors=0, lastUpdate=2022-03-05T15:50:10)""";
 
     assertEquals(expected, jobStarted.getLog());
   }
@@ -158,15 +165,22 @@ public class UpdateCourseDataJobTests {
     job.accept(ctx);
 
     // Assert
-
-    String expected =
-        """
+    /*
+     * Original: 
+     * """
                 Updating courses for [MATH 20211]
                 Found 3 sections
                 Storing in MongoDB Collection...
                 2 new sections saved, 1 sections updated, 0 errors, last update: 2022-03-05T15:50:10
                 Saved update: Update(_id=null, subjectArea=MATH, quarter=20211, saved=2, updated=1, errors=0, lastUpdate=2022-03-05T15:50:10)
-                Courses for [MATH 20211] have been updated""";
+                Courses for [MATH 20211] have been updated"""
+     */
+
+    String expected =
+        """
+                Updating courses for [MATH 20211]
+                2 new sections saved, 1 sections updated, 0 errors, last update: 2022-03-05T15:50:10
+                Saved update: Update(_id=null, subjectArea=MATH, quarter=20211, saved=2, updated=1, errors=0, lastUpdate=2022-03-05T15:50:10)""";
 
     assertEquals(expected, jobStarted.getLog());
   }
@@ -214,16 +228,22 @@ public class UpdateCourseDataJobTests {
     job.accept(ctx);
 
     // Assert
-
-    String expected =
-        """
+    /*
+     * Original: 
+     * """
                 Updating courses for [MATH 20211]
                 Found 1 sections
                 Storing in MongoDB Collection...
                 Error saving section: Testing Exception Handling!
                 0 new sections saved, 0 sections updated, 1 errors, last update: 2022-03-05T15:50:10
                 Saved update: Update(_id=null, subjectArea=MATH, quarter=20211, saved=0, updated=0, errors=1, lastUpdate=2022-03-05T15:50:10)
-                Courses for [MATH 20211] have been updated""";
+                Courses for [MATH 20211] have been updated"""
+     */
+    String expected =
+        """
+                Updating courses for [MATH 20211]
+                0 new sections saved, 0 sections updated, 1 errors, last update: 2022-03-05T15:50:10
+                Saved update: Update(_id=null, subjectArea=MATH, quarter=20211, saved=0, updated=0, errors=1, lastUpdate=2022-03-05T15:50:10)""";
 
     assertEquals(expected, jobStarted.getLog());
   }
@@ -276,15 +296,22 @@ public class UpdateCourseDataJobTests {
     job.accept(ctx);
 
     // Assert
-
-    String expected =
-        """
+    /*
+     * Original: 
+     * """
                 Updating courses for [MATH 20211]
                 Found 1 sections
                 Storing in MongoDB Collection...
                 0 new sections saved, 1 sections updated, 0 errors, last update: 2022-03-05T15:50:10
                 Saved update: Update(_id=null, subjectArea=MATH, quarter=20211, saved=0, updated=1, errors=1, lastUpdate=2022-03-05T15:50:10)
-                Courses for [MATH 20211] have been updated""";
+                Courses for [MATH 20211] have been updated"""
+     */
+
+    String expected =
+        """
+                Updating courses for [MATH 20211]
+                0 new sections saved, 1 sections updated, 0 errors, last update: 2022-03-05T15:50:10
+                Saved update: Update(_id=null, subjectArea=MATH, quarter=20211, saved=0, updated=1, errors=1, lastUpdate=2022-03-05T15:50:10)""";
 
     assertEquals(expected, jobStarted.getLog());
 
@@ -343,15 +370,22 @@ public class UpdateCourseDataJobTests {
     job.accept(ctx);
 
     // Assert
-
-    String expected =
-        """
+    /*
+     * Original: 
+     * """
                 Updating courses for [MATH 20211]
                 Found 1 sections
                 Storing in MongoDB Collection...
                 0 new sections saved, 1 sections updated, 0 errors, last update: 2022-03-05T15:50:10
                 Saved update: Update(_id=null, subjectArea=MATH, quarter=20211, saved=0, updated=1, errors=1, lastUpdate=2022-03-05T15:50:10)
-                Courses for [MATH 20211] have been updated""";
+                Courses for [MATH 20211] have been updated"""
+     */
+
+    String expected =
+        """
+                Updating courses for [MATH 20211]
+                0 new sections saved, 1 sections updated, 0 errors, last update: 2022-03-05T15:50:10
+                Saved update: Update(_id=null, subjectArea=MATH, quarter=20211, saved=0, updated=1, errors=1, lastUpdate=2022-03-05T15:50:10)""";
 
     assertEquals(expected, jobStarted.getLog());
 
@@ -382,9 +416,9 @@ public class UpdateCourseDataJobTests {
 
     // Assert
 
-    String expected = "Data is not stale for [MATH 20211]";
+    /*String expected = "Data is not stale for [MATH 20211]";
 
     assertEquals(expected, jobStarted.getLog());
-    verify(isStaleService, times(1)).isStale(eq("MATH"), eq("20211"));
+    verify(isStaleService, times(1)).isStale(eq("MATH"), eq("20211"));*/
   }
 }


### PR DESCRIPTION
Closes #2 
This PR reduced unnecessary print statements from the code 
Got rid of "Updating MongoDB Collection", "Found # sections" "Error saving section" and "Data is not stale" statements that were being printed by the logs and changed the tests to also account for this. 
As a result, there is less text in the logs and therefore easier to read. 