### PR TITLE
Feature: Admins can now purge job log 

### DIFF
--- a/frontend/src/main/components/Jobs/ClearJobLogsForm.js
+++ b/frontend/src/main/components/Jobs/ClearJobLogsForm.js
@@ -5,7 +5,7 @@ const ClearJobLogsForm = ({ clearJobLogs }) => {
     event.preventDefault();
     clearJobLogs();
   };
-
+// Stryker disable all
   return (
     <Form onSubmit={handleSubmit}>
       <Container>

--- a/frontend/src/main/components/Jobs/ClearJobLogsForm.js
+++ b/frontend/src/main/components/Jobs/ClearJobLogsForm.js
@@ -1,9 +1,9 @@
 import { Form, Button, Container, Row, Col } from "react-bootstrap";
 
-const ClearJobLogsForm = ({ clearJobLogs }) => {
+const ClearJobLogsForm = ({ callback }) => {
   const handleSubmit = (event) => {
     event.preventDefault();
-    clearJobLogs();
+    callback();
   };
   // Stryker disable all
   return (

--- a/frontend/src/main/components/Jobs/ClearJobLogsForm.js
+++ b/frontend/src/main/components/Jobs/ClearJobLogsForm.js
@@ -1,0 +1,28 @@
+import { Form, Button, Container, Row, Col } from "react-bootstrap";
+
+const ClearJobLogsForm = ({ clearJobLogs }) => {
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    clearJobLogs();
+  };
+
+  return (
+    <Form onSubmit={handleSubmit}>
+      <Container>
+        <Row style={{ paddingTop: 8, paddingBottom: 8 }}>
+          <Col md="auto">
+            <Button
+              variant="danger"
+              type="submit"
+              data-testid="clearJobLogsButn"
+            >
+              Clear Jobs
+            </Button>
+          </Col>
+        </Row>
+      </Container>
+    </Form>
+  );
+};
+
+export default ClearJobLogsForm;

--- a/frontend/src/main/components/Jobs/ClearJobLogsForm.js
+++ b/frontend/src/main/components/Jobs/ClearJobLogsForm.js
@@ -5,11 +5,11 @@ const ClearJobLogsForm = ({ callback }) => {
     event.preventDefault();
     callback();
   };
-  // Stryker disable all
+
   return (
     <Form onSubmit={handleSubmit}>
       <Container>
-        <Row style={{ paddingTop: 8, paddingBottom: 8 }}>
+        <Row>
           <Col md="auto">
             <Button
               variant="danger"

--- a/frontend/src/main/components/Jobs/ClearJobLogsForm.js
+++ b/frontend/src/main/components/Jobs/ClearJobLogsForm.js
@@ -5,7 +5,7 @@ const ClearJobLogsForm = ({ clearJobLogs }) => {
     event.preventDefault();
     clearJobLogs();
   };
-// Stryker disable all
+  // Stryker disable all
   return (
     <Form onSubmit={handleSubmit}>
       <Container>

--- a/frontend/src/main/pages/Admin/AdminJobsPage.js
+++ b/frontend/src/main/pages/Admin/AdminJobsPage.js
@@ -5,6 +5,7 @@ import { useBackend } from "main/utils/useBackend";
 import Accordion from "react-bootstrap/Accordion";
 import TestJobForm from "main/components/Jobs/TestJobForm";
 import UpdateGradeInfoForm from "main/components/Jobs/UpdateGradeInfoForm";
+import ClearJobLogsForm from "main/components/Jobs/ClearJobLogsForm";
 
 import { useBackendMutation } from "main/utils/useBackend";
 import UpdateCoursesJobForm from "main/components/Jobs/UpdateCoursesJobForm";
@@ -33,6 +34,11 @@ const AdminJobsPage = () => {
 
   // ***** update courses job *******
 
+  const objectToAxiosParamsClearJobLogs = () => ({
+    url: "/api/jobs/all",
+    method: "DELETE",
+  });
+
   const objectToAxiosParamsUpdateCoursesJob = (data) => ({
     url: `/api/jobs/launch/updateCourses?quarterYYYYQ=${data.quarter}&subjectArea=${data.subject}&ifStale=${data.ifStale}`,
     method: "POST",
@@ -54,6 +60,11 @@ const AdminJobsPage = () => {
   });
 
   // Stryker disable all
+  const clearJobLogsMutation = useBackendMutation(
+    objectToAxiosParamsClearJobLogs,
+    {},
+    ["/api/jobs/all"],
+  );
   const updateCoursesJobMutation = useBackendMutation(
     objectToAxiosParamsUpdateCoursesJob,
     {},
@@ -77,6 +88,10 @@ const AdminJobsPage = () => {
     ["/api/jobs/all"],
   );
   // Stryker restore all
+
+  const clearJobLogs = async () => {
+    clearJobLogsMutation.mutate();
+  };
 
   const submitUpdateCoursesJob = async (data) => {
     updateCoursesJobMutation.mutate(data);
@@ -114,6 +129,10 @@ const AdminJobsPage = () => {
     {
       name: "Test Job",
       form: <TestJobForm submitAction={submitTestJob} />,
+    },
+    {
+      name: "Clear Job Logs",
+      form: <ClearJobLogsForm clearJobLogs={clearJobLogs} />,
     },
     {
       name: "Update Courses Database",

--- a/frontend/src/main/pages/Admin/AdminJobsPage.js
+++ b/frontend/src/main/pages/Admin/AdminJobsPage.js
@@ -132,7 +132,7 @@ const AdminJobsPage = () => {
     },
     {
       name: "Clear Job Logs",
-      form: <ClearJobLogsForm clearJobLogs={clearJobLogs} />,
+      form: <ClearJobLogsForm callback={clearJobLogs} />,
     },
     {
       name: "Update Courses Database",

--- a/frontend/src/tests/components/Jobs/TestClearJobLogForm.test.js
+++ b/frontend/src/tests/components/Jobs/TestClearJobLogForm.test.js
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router-dom";
+import ClearJobLogsForm from "main/components/Jobs/ClearJobLogsForm";
+import { QueryClient, QueryClientProvider } from "react-query";
+
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockedNavigate = jest.fn();
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockedNavigate,
+}));
+
+const queryClient = new QueryClient();
+
+describe("ClearJobLogsForm tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  it("renders correctly", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <ClearJobLogsForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByText(/Clear/)).toBeInTheDocument();
+  });
+
+  test("renders without crashing when fallback values are used", async () => {
+    axiosMock.onGet("/api/systemInfo").reply(200, {
+      springH2ConsoleEnabled: false,
+      showSwaggerUILink: false,
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <ClearJobLogsForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByTestId("clearJobLogsButn")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/pages/AdminJobsPage.test.js
+++ b/frontend/src/tests/pages/AdminJobsPage.test.js
@@ -255,4 +255,30 @@ describe("AdminJobsPage tests", () => {
     await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
     expect(axiosMock.history.post[0].url).toBe(url);
   });
+  test("user can clear job logs", async () => {
+    const url = "/api/jobs/clear";
+    axiosMock.onPost(url).reply(200, {});
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AdminJobsPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText("Clear Job Logs")).toBeInTheDocument();
+
+    const clearJobLogsButton = screen.getByText("Clear Job Logs");
+    expect(clearJobLogsButton).toBeInTheDocument();
+    clearJobLogsButton.click();
+
+    const submitClearJobLogButton = screen.getByTestId("clearJobLogsButn");
+    expect(submitClearJobLogButton).toBeInTheDocument();
+
+    submitClearJobLogButton.click();
+
+    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+    expect(axiosMock.history.post[0].url).toBe(url);
+  });
 });

--- a/frontend/src/tests/pages/AdminJobsPage.test.js
+++ b/frontend/src/tests/pages/AdminJobsPage.test.js
@@ -256,8 +256,8 @@ describe("AdminJobsPage tests", () => {
     expect(axiosMock.history.post[0].url).toBe(url);
   });
   test("user can clear job logs", async () => {
-    const url = "/api/jobs/clear";
-    axiosMock.onPost(url).reply(200, {});
+    const url = "/api/jobs/all";
+    axiosMock.onDelete(url).reply(200, {});
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -273,12 +273,11 @@ describe("AdminJobsPage tests", () => {
     expect(clearJobLogsButton).toBeInTheDocument();
     clearJobLogsButton.click();
 
-    const submitClearJobLogButton = screen.getByTestId("clearJobLogsButn");
-    expect(submitClearJobLogButton).toBeInTheDocument();
+    const submitClearJobLogsButton = screen.getByTestId("clearJobsSubmit");
+    expect(submitClearJobLogsButton).toBeInTheDocument();
+    submitClearJobLogsButton.click();
 
-    submitClearJobLogButton.click();
-
-    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
-    expect(axiosMock.history.post[0].url).toBe(url);
+    await waitFor(() => expect(axiosMock.history.delete.length).toBe(1));
+    expect(axiosMock.history.delete[0].url).toBe(url);
   });
 });

--- a/frontend/src/tests/pages/AdminJobsPage.test.js
+++ b/frontend/src/tests/pages/AdminJobsPage.test.js
@@ -273,7 +273,7 @@ describe("AdminJobsPage tests", () => {
     expect(clearJobLogsButton).toBeInTheDocument();
     clearJobLogsButton.click();
 
-    const submitClearJobLogsButton = screen.getByTestId("clearJobsSubmit");
+    const submitClearJobLogsButton = screen.getByTestId("clearJobLogsButn");
     expect(submitClearJobLogsButton).toBeInTheDocument();
     submitClearJobLogsButton.click();
 


### PR DESCRIPTION
Closes #11. 

Admin users are now capable of purging the job log when they go to the "Manage Jobs" tab. 
There is a tab that says "Clear Job Logs" and upon clicking the dropdown, there is a button that says "Clear Job Logs" and once the user clicks this, the job logs that were previously displayed are now gone.

Test [here](https://courses-issue11.dokku-03.cs.ucsb.edu/)

<img width="1267" alt="image" src="https://github.com/user-attachments/assets/09f1de4f-e67f-4120-be51-e77993707767">
After clicking the button
<img width="1267" alt="image" src="https://github.com/user-attachments/assets/2fefad83-9ccb-42ad-9b99-aaa3523e2886">
