### PR TITLE
Create AdminUpdatesPage Placeholder

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -4,6 +4,7 @@ import ProfilePage from "main/pages/ProfilePage";
 import AdminUsersPage from "main/pages/Admin/AdminUsersPage";
 import AdminLoadSubjectsPage from "main/pages/Admin/AdminLoadSubjectsPage";
 import AdminJobsPage from "main/pages/Admin/AdminJobsPage";
+import AdminUpdatesPage from "main/pages/Admin/AdminUpdatesPage";
 import DeveloperPage from "main/pages/DeveloperPage"; // route from /developer to DeveloperPage
 
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
@@ -40,6 +41,7 @@ function App() {
               element={<AdminLoadSubjectsPage />}
             />
             <Route path="/admin/jobs" element={<AdminJobsPage />} />
+            <Route path="/admin/updates" element={<AdminUpdatesPage />} />
             <Route path="/developer" element={<DeveloperPage />} />
           </>
         )}

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -133,6 +133,12 @@ export default function AppNavbar({
                     Manage Jobs
                   </NavDropdown.Item>
                   <NavDropdown.Item
+                    href="/admin/updates"
+                    data-testid="appnavbar-admin-updates"
+                  >
+                    Updates
+                  </NavDropdown.Item>
+                  <NavDropdown.Item
                     href="/developer"
                     data-testid="appnavbar-developer"
                   >

--- a/frontend/src/main/pages/Admin/AdminUpdatesPage.js
+++ b/frontend/src/main/pages/Admin/AdminUpdatesPage.js
@@ -1,0 +1,12 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function AdminUpdatesPage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Updates page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/Admin/AdminUpdatesPage.js
+++ b/frontend/src/main/pages/Admin/AdminUpdatesPage.js
@@ -4,9 +4,7 @@ export default function AdminUpdatesPage() {
   // Stryker disable all : placeholder for future implementation
   return (
     <BasicLayout>
-      <div className="pt-2">
-        <h1>Updates page not yet implemented</h1>
-      </div>
+      <h1>Updates page not yet implemented</h1>
     </BasicLayout>
   );
 }

--- a/frontend/src/stories/pages/Admin/AdminUpdatesPage.stories.js
+++ b/frontend/src/stories/pages/Admin/AdminUpdatesPage.stories.js
@@ -1,12 +1,5 @@
 import React from "react";
 import AdminUpdatesPage from "main/pages/Admin/AdminUpdatesPage";
-import jobsFixtures from "fixtures/jobsFixtures";
-import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
-import { ucsbSubjectsFixtures } from "fixtures/ucsbSubjectsFixtures";
-import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
-
-import { toast } from "react-toastify";
-import { http, HttpResponse } from "msw";
 
 export default {
   title: "pages/Admin/AdminUpdatesPage",
@@ -16,42 +9,3 @@ export default {
 const Template = () => <AdminUpdatesPage />;
 
 export const Default = Template.bind({});
-Default.parameters = {
-  msw: [
-    http.get("/api/UCSBSubjects/all", () => {
-      return HttpResponse.json(ucsbSubjectsFixtures.threeSubjects, {
-        status: 200,
-      });
-    }),
-    http.post("/api/UCSBSubjects/load", ({ request }) => {
-      toast(`Generated: ${request.method} ${request.url}`);
-      return HttpResponse.json(ucsbSubjectsFixtures.threeSubjects, {
-        status: 200,
-      });
-    }),
-    http.get("/api/jobs/all", () => {
-      return HttpResponse.json(jobsFixtures.sixJobs, {
-        status: 200,
-      });
-    }),
-    http.get("/api/systemInfo", () => {
-      return HttpResponse.json(systemInfoFixtures.showingBoth, {
-        status: 200,
-      });
-    }),
-    http.get("/api/currentUser", () => {
-      return HttpResponse.json(apiCurrentUserFixtures.adminUser, {
-        status: 200,
-      });
-    }),
-    http.post("/logout", ({ request }) => {
-      toast(`Generated: ${request.method} ${request.url}`);
-      return HttpResponse.json(
-        {},
-        {
-          status: 200,
-        },
-      );
-    }),
-  ],
-};

--- a/frontend/src/stories/pages/Admin/AdminUpdatesPage.stories.js
+++ b/frontend/src/stories/pages/Admin/AdminUpdatesPage.stories.js
@@ -1,0 +1,57 @@
+import React from "react";
+import AdminUpdatesPage from "main/pages/Admin/AdminUpdatesPage";
+import jobsFixtures from "fixtures/jobsFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { ucsbSubjectsFixtures } from "fixtures/ucsbSubjectsFixtures";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+
+import { toast } from "react-toastify";
+import { http, HttpResponse } from "msw";
+
+export default {
+  title: "pages/Admin/AdminUpdatesPage",
+  component: AdminUpdatesPage,
+};
+
+const Template = () => <AdminUpdatesPage />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/UCSBSubjects/all", () => {
+      return HttpResponse.json(ucsbSubjectsFixtures.threeSubjects, {
+        status: 200,
+      });
+    }),
+    http.post("/api/UCSBSubjects/load", ({ request }) => {
+      toast(`Generated: ${request.method} ${request.url}`);
+      return HttpResponse.json(ucsbSubjectsFixtures.threeSubjects, {
+        status: 200,
+      });
+    }),
+    http.get("/api/jobs/all", () => {
+      return HttpResponse.json(jobsFixtures.sixJobs, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingBoth, {
+        status: 200,
+      });
+    }),
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.adminUser, {
+        status: 200,
+      });
+    }),
+    http.post("/logout", ({ request }) => {
+      toast(`Generated: ${request.method} ${request.url}`);
+      return HttpResponse.json(
+        {},
+        {
+          status: 200,
+        },
+      );
+    }),
+  ],
+};

--- a/frontend/src/tests/pages/AdminUpdatesPage.test.js
+++ b/frontend/src/tests/pages/AdminUpdatesPage.test.js
@@ -1,13 +1,13 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import AdminUpdatesPage from "main/pages/Admin/AdminUpdatesPage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
-import axios from "axios";
-import AxiosMockAdapter from "axios-mock-adapter";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
-// import { updateFixtures } from "fixtures/updateFixtures";
-import AdminUpdatesPage from "main/pages/Admin/AdminUpdatesPage";
+
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
 
 const mockToast = jest.fn();
 jest.mock("react-toastify", () => {
@@ -19,26 +19,36 @@ jest.mock("react-toastify", () => {
   };
 });
 
+const mockNavigate = jest.fn();
+jest.mock("react-router-dom", () => {
+  const originalModule = jest.requireActual("react-router-dom");
+  return {
+    __esModule: true,
+    ...originalModule,
+    Navigate: (x) => {
+      mockNavigate(x);
+      return null;
+    },
+  };
+});
+
 describe("AdminUpdatesPage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
-  const testId = "UpdatesTable";
 
-  const setupAdminUser = () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
     axiosMock.reset();
     axiosMock.resetHistory();
     axiosMock
       .onGet("/api/currentUser")
-      .reply(200, apiCurrentUserFixtures.adminUser);
+      .reply(200, apiCurrentUserFixtures.userOnly);
     axiosMock
       .onGet("/api/systemInfo")
       .reply(200, systemInfoFixtures.showingNeither);
-  };
+  });
 
-  test("renders without crashing for admin user", () => {
-    setupAdminUser();
-    const queryClient = new QueryClient();
-    axiosMock.onGet("/api/updates/all").reply(200, []);
-
+  const queryClient = new QueryClient();
+  test("renders without crashing", async () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -47,83 +57,4 @@ describe("AdminUpdatesPage tests", () => {
       </QueryClientProvider>,
     );
   });
-
-  //   test("renders three earthquakes without crashing for regular user", async () => {
-  //     setupAdminUser();
-  //     const queryClient = new QueryClient();
-  //     axiosMock
-  //       .onGet("/api/updates/all")
-  //       .reply(200, updateFixtures.threeUpdates);
-
-  //     render(
-  //       <QueryClientProvider client={queryClient}>
-  //         <MemoryRouter>
-  //           <AdminUpdatesPage />
-  //         </MemoryRouter>
-  //       </QueryClientProvider>,
-  //     );
-
-  //     expect(
-  //       await screen.findByTestId(`${testId}-cell-row-0-col-subjectArea`),
-  //     ).toHaveTextContent("EARTH");
-  //     expect(
-  //       screen.getByTestId(`${testId}-cell-row-1-col-subjectArea`),
-  //     ).toHaveTextContent("CMPSC");
-  //     expect(
-  //       screen.getByTestId(`${testId}-cell-row-2-col-subjectArea`),
-  //     ).toHaveTextContent("PSTAT");
-  //   });
-
-  //   test("what happens when you click load, admin - originally nothing in table, load 3 subjects", async () => {
-  //     setupAdminUser();
-  //     const queryClient = new QueryClient();
-  //     axiosMock.onGet("/api/UCSBSubjects/all").reply(200, []);
-  //     axiosMock
-  //       .onPost("/api/updates/load")
-  //       .reply(200, updateFixtures.threeUpdates);
-
-  //     render(
-  //       <QueryClientProvider client={queryClient}>
-  //         <MemoryRouter>
-  //           <AdminUpdatesPage />
-  //         </MemoryRouter>
-  //       </QueryClientProvider>,
-  //     );
-
-  //     expect(
-  //       await screen.findByTestId(`AdminUpdates-Load-Button`),
-  //     ).toBeInTheDocument();
-
-  //     const loadButton = screen.getByTestId(`AdminUpdates-Load-Button`);
-  //     expect(loadButton).toBeInTheDocument();
-  //     fireEvent.click(loadButton);
-
-  //     await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
-  //     expect(mockToast).toHaveBeenCalledWith("Number of Subjects Loaded : 3");
-  //   });
-
-  //   test("what happens when you click load, admin - originally 3 subjects, load nothing", async () => {
-  //     setupAdminUser();
-  //     const queryClient = new QueryClient();
-  //     axiosMock
-  //       .onGet("/api/updates/all")
-  //       .reply(200, updateFixtures.threeUpdates);
-  //     axiosMock.onPost("/api/updates/load").reply(200, []);
-
-  //     render(
-  //       <QueryClientProvider client={queryClient}>
-  //         <MemoryRouter>
-  //           <AdminUpdatesPage />
-  //         </MemoryRouter>
-  //       </QueryClientProvider>,
-  //     );
-
-  //     expect(
-  //       await screen.findByTestId(`AdminUpdates-Load-Button`),
-  //     ).toBeInTheDocument();
-
-  //     const loadButton = screen.getByTestId(`AdminUpdates-Load-Button`);
-  //     expect(loadButton).toBeInTheDocument();
-  //     fireEvent.click(loadButton);
-  //   });
 });

--- a/frontend/src/tests/pages/AdminUpdatesPage.test.js
+++ b/frontend/src/tests/pages/AdminUpdatesPage.test.js
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import AdminUpdatesPage from "main/pages/Admin/AdminUpdatesPage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
@@ -56,5 +56,6 @@ describe("AdminUpdatesPage tests", () => {
         </MemoryRouter>
       </QueryClientProvider>,
     );
+    await screen.findAllByText("Updates page not yet implemented");
   });
 });

--- a/frontend/src/tests/pages/AdminUpdatesPage.test.js
+++ b/frontend/src/tests/pages/AdminUpdatesPage.test.js
@@ -1,0 +1,129 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+// import { updateFixtures } from "fixtures/updateFixtures";
+import AdminUpdatesPage from "main/pages/Admin/AdminUpdatesPage";
+
+const mockToast = jest.fn();
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
+});
+
+describe("AdminUpdatesPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+  const testId = "UpdatesTable";
+
+  const setupAdminUser = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.adminUser);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  test("renders without crashing for admin user", () => {
+    setupAdminUser();
+    const queryClient = new QueryClient();
+    axiosMock.onGet("/api/updates/all").reply(200, []);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AdminUpdatesPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+  });
+
+  //   test("renders three earthquakes without crashing for regular user", async () => {
+  //     setupAdminUser();
+  //     const queryClient = new QueryClient();
+  //     axiosMock
+  //       .onGet("/api/updates/all")
+  //       .reply(200, updateFixtures.threeUpdates);
+
+  //     render(
+  //       <QueryClientProvider client={queryClient}>
+  //         <MemoryRouter>
+  //           <AdminUpdatesPage />
+  //         </MemoryRouter>
+  //       </QueryClientProvider>,
+  //     );
+
+  //     expect(
+  //       await screen.findByTestId(`${testId}-cell-row-0-col-subjectArea`),
+  //     ).toHaveTextContent("EARTH");
+  //     expect(
+  //       screen.getByTestId(`${testId}-cell-row-1-col-subjectArea`),
+  //     ).toHaveTextContent("CMPSC");
+  //     expect(
+  //       screen.getByTestId(`${testId}-cell-row-2-col-subjectArea`),
+  //     ).toHaveTextContent("PSTAT");
+  //   });
+
+  //   test("what happens when you click load, admin - originally nothing in table, load 3 subjects", async () => {
+  //     setupAdminUser();
+  //     const queryClient = new QueryClient();
+  //     axiosMock.onGet("/api/UCSBSubjects/all").reply(200, []);
+  //     axiosMock
+  //       .onPost("/api/updates/load")
+  //       .reply(200, updateFixtures.threeUpdates);
+
+  //     render(
+  //       <QueryClientProvider client={queryClient}>
+  //         <MemoryRouter>
+  //           <AdminUpdatesPage />
+  //         </MemoryRouter>
+  //       </QueryClientProvider>,
+  //     );
+
+  //     expect(
+  //       await screen.findByTestId(`AdminUpdates-Load-Button`),
+  //     ).toBeInTheDocument();
+
+  //     const loadButton = screen.getByTestId(`AdminUpdates-Load-Button`);
+  //     expect(loadButton).toBeInTheDocument();
+  //     fireEvent.click(loadButton);
+
+  //     await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+  //     expect(mockToast).toHaveBeenCalledWith("Number of Subjects Loaded : 3");
+  //   });
+
+  //   test("what happens when you click load, admin - originally 3 subjects, load nothing", async () => {
+  //     setupAdminUser();
+  //     const queryClient = new QueryClient();
+  //     axiosMock
+  //       .onGet("/api/updates/all")
+  //       .reply(200, updateFixtures.threeUpdates);
+  //     axiosMock.onPost("/api/updates/load").reply(200, []);
+
+  //     render(
+  //       <QueryClientProvider client={queryClient}>
+  //         <MemoryRouter>
+  //           <AdminUpdatesPage />
+  //         </MemoryRouter>
+  //       </QueryClientProvider>,
+  //     );
+
+  //     expect(
+  //       await screen.findByTestId(`AdminUpdates-Load-Button`),
+  //     ).toBeInTheDocument();
+
+  //     const loadButton = screen.getByTestId(`AdminUpdates-Load-Button`);
+  //     expect(loadButton).toBeInTheDocument();
+  //     fireEvent.click(loadButton);
+  //   });
+});


### PR DESCRIPTION
Closes #21. Adds a new page to the Admins dropdown (implemented as a placeholder for now) that is only available to Admins. Log in as an admin to view the page in the associated dokku application. 

<img width="1392" alt="Screenshot 2024-11-20 at 11 24 37 AM" src="https://github.com/user-attachments/assets/ec6d811b-578d-4aed-8741-6e76b8c6d1ec">

Dokku deployment: https://courses-chloe.dokku-03.cs.ucsb.edu/