### PR TITLE
Detailed log page for long running jobs

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -23,6 +23,8 @@ import CourseOverTimeInstructorIndexPage from "main/pages/CourseOverTime/CourseO
 import CourseOverTimeBuildingsIndexPage from "main/pages/CourseOverTime/CourseOverTimeBuildingsIndexPage";
 
 import CourseDetailsIndexPage from "main/pages/CourseDetails/CourseDetailsIndexPage";
+
+import JobsLogPage from "main/pages/Jobs/JobsLogPage";
 function App() {
   const { data: currentUser } = useCurrentUser();
 
@@ -93,6 +95,10 @@ function App() {
           element={<CourseDetailsIndexPage />}
         />
       </Routes>
+      <Routes>
+        <Route path="/admin/jobs/logs/:id" element={<JobsLogPage />} />
+      </Routes>
+      ;
     </BrowserRouter>
   );
 }

--- a/frontend/src/main/components/Jobs/JobsLogTable.js
+++ b/frontend/src/main/components/Jobs/JobsLogTable.js
@@ -1,0 +1,58 @@
+import React from "react";
+import OurTable from "main/components/OurTable";
+
+function JobLogTable({ job }) {
+  const testid = "JobLogTable";
+
+  // Ensure job and log data are present
+  if (!job) {
+    return <p data-testid={`${testid}-not-found`}>Job not found.</p>;
+  }
+
+  const logLines = job.log ? job.log.split("\n") : [];
+
+  const logData = logLines.map((line, index) => ({
+    index: index + 1,
+    logLine: line,
+  }));
+
+  const logColumns = [
+    {
+      Header: "#",
+      accessor: "index", // accessor is the "key" in the data
+    },
+    {
+      Header: "Log Line",
+      accessor: "logLine",
+    },
+  ];
+
+  const jobData = [
+    { field: "ID", value: job.id },
+    { field: "Created", value: new Date(job.createdAt).toLocaleString() },
+    { field: "Updated", value: new Date(job.updatedAt).toLocaleString() },
+    { field: "Status", value: job.status },
+  ];
+
+  const jobColumns = [
+    {
+      Header: "Field",
+      accessor: "field",
+    },
+    {
+      Header: "Value",
+      accessor: "value",
+    },
+  ];
+
+  return (
+    <div>
+      <h3>Job Information</h3>
+      <OurTable data={jobData} columns={jobColumns} testid={testid} />
+      <h3>Job Log</h3>
+      <OurTable data={logData} columns={logColumns} testid={testid} />
+    </div>
+  );
+}
+
+export default JobLogTable;

--- a/frontend/src/main/pages/Jobs/JobsLogPage.js
+++ b/frontend/src/main/pages/Jobs/JobsLogPage.js
@@ -30,13 +30,14 @@ export default function JobsLogPage() {
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Job Log Details</h1>
-        <JobLogTable job={job} />
-
         {/* Back Button */}
         <Button variant="secondary" onClick={navigateCallback}>
           Back to Jobs Table
         </Button>
+
+        <h1>Job Log Details</h1>
+        <JobLogTable job={job} />
+
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/Jobs/JobsLogPage.js
+++ b/frontend/src/main/pages/Jobs/JobsLogPage.js
@@ -9,22 +9,23 @@ export default function JobsLogPage() {
   let { id } = useParams();
   const navigate = useNavigate();
 
-  // Fetch the job details based on the job ID
+  // Stryker disable all
   const {
     data: jobs,
     _error,
     _status,
-  } = useBackend([`/api/jobs/${id}`], {
+  } = useBackend([`/api/jobs/all`], {
     method: "GET",
     url: `/api/jobs/all`,
   });
-
-  const job = jobs ? jobs.find((job) => String(job.id) === id) : null;
 
   // Navigate back to the jobs table
   const navigateCallback = () => {
     navigate("/admin/jobs");
   };
+  // Stryker restore all
+
+  const job = jobs ? jobs.find((job) => String(job.id) === id) : null;
 
   return (
     <BasicLayout>
@@ -33,11 +34,7 @@ export default function JobsLogPage() {
         <JobLogTable job={job} />
 
         {/* Back Button */}
-        <Button
-          variant="secondary"
-          onClick={navigateCallback}
-          style={{ marginTop: "20px" }}
-        >
+        <Button variant="secondary" onClick={navigateCallback}>
           Back to Jobs Table
         </Button>
       </div>

--- a/frontend/src/main/pages/Jobs/JobsLogPage.js
+++ b/frontend/src/main/pages/Jobs/JobsLogPage.js
@@ -1,0 +1,46 @@
+import React from "react";
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams, useNavigate } from "react-router-dom";
+import { useBackend } from "main/utils/useBackend";
+import { Button } from "react-bootstrap";
+import JobLogTable from "main/components/Jobs/JobsLogTable";
+
+export default function JobsLogPage() {
+  let { id } = useParams();
+  const navigate = useNavigate();
+
+  // Fetch the job details based on the job ID
+  const {
+    data: jobs,
+    _error,
+    _status,
+  } = useBackend([`/api/jobs/${id}`], {
+    method: "GET",
+    url: `/api/jobs/all`,
+  });
+
+  const job = jobs ? jobs.find((job) => String(job.id) === id) : null;
+
+  // Navigate back to the jobs table
+  const navigateCallback = () => {
+    navigate("/admin/jobs");
+  };
+
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Job Log Details</h1>
+        <JobLogTable job={job} />
+
+        {/* Back Button */}
+        <Button
+          variant="secondary"
+          onClick={navigateCallback}
+          style={{ marginTop: "20px" }}
+        >
+          Back to Jobs Table
+        </Button>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/Jobs/JobsLogPage.js
+++ b/frontend/src/main/pages/Jobs/JobsLogPage.js
@@ -37,7 +37,6 @@ export default function JobsLogPage() {
 
         <h1>Job Log Details</h1>
         <JobLogTable job={job} />
-
       </div>
     </BasicLayout>
   );

--- a/frontend/src/tests/components/Jobs/JobsLogsTable.test.js
+++ b/frontend/src/tests/components/Jobs/JobsLogsTable.test.js
@@ -1,0 +1,79 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import JobsLogTable from "main/components/Jobs/JobsLogTable";
+import jobsFixtures from "fixtures/jobsFixtures";
+
+describe("JobsLogTable tests", () => {
+  const queryClient = new QueryClient();
+
+  test("renders without crashing for empty table", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <JobsLogTable />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+  });
+
+  test("Has the expected column headers and content", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <JobsLogTable job={jobsFixtures.oneCompleteJob} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const expectedHeaders = ["ID", "Created", "Updated", "Status", "Field", "Value", "#", "Log Line"];
+    const testId = "JobsTable";
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("JobLogTable-cell-row-0-col-field")).toHaveTextContent(
+      "ID",
+    );
+    expect(screen.getByTestId("JobLogTable-cell-row-0-col-value")).toHaveTextContent(
+      "1",
+    );
+    expect(screen.getByTestId("JobLogTable-cell-row-1-col-field")).toHaveTextContent(
+      "Created",
+    );
+    expect(screen.getByTestId("JobLogTable-cell-row-1-col-value")).toHaveTextContent(
+      "11/13/2022, 7:49:58 PM",
+    );
+    expect(screen.getByTestId("JobLogTable-cell-row-2-col-field")).toHaveTextContent(
+      "Updated",
+    );
+    expect(screen.getByTestId("JobLogTable-cell-row-2-col-value")).toHaveTextContent(
+      "11/13/2022, 7:49:59 PM",
+    );
+    expect(screen.getByTestId("JobLogTable-cell-row-3-col-field")).toHaveTextContent(
+      "Status",
+    );
+    expect(screen.getByTestId("JobLogTable-cell-row-3-col-value")).toHaveTextContent(
+      "complete",
+    );
+
+    expect(
+      screen.getByTestId("JobLogTable-cell-row-0-col-index"),
+    ).toHaveTextContent("1");
+
+    expect(
+      screen.getByTestId("JobLogTable-cell-row-0-col-logLine"),
+    ).toHaveTextContent("Hello World! from test job");
+
+    expect(
+        screen.getByTestId("JobLogTable-cell-row-1-col-index"),
+      ).toHaveTextContent("2");
+  
+      expect(
+        screen.getByTestId("JobLogTable-cell-row-1-col-logLine"),
+      ).toHaveTextContent("Goodbye from test job!");
+
+  });
+});

--- a/frontend/src/tests/components/Jobs/JobsLogsTable.test.js
+++ b/frontend/src/tests/components/Jobs/JobsLogsTable.test.js
@@ -85,7 +85,7 @@ describe("JobsLogTable tests", () => {
     ).toHaveTextContent("Goodbye from test job!");
   });
 
-  test("Has the expected column headers and content", () => {
+  test("Has the expected column headers and content for empty log", () => {
     const emptyJob = {
       id: 1,
       createdAt: "2022-11-13T19:49:58.097465-08:00",

--- a/frontend/src/tests/components/Jobs/JobsLogsTable.test.js
+++ b/frontend/src/tests/components/Jobs/JobsLogsTable.test.js
@@ -26,7 +26,16 @@ describe("JobsLogTable tests", () => {
       </QueryClientProvider>,
     );
 
-    const expectedHeaders = ["ID", "Created", "Updated", "Status", "Field", "Value", "#", "Log Line"];
+    const expectedHeaders = [
+      "ID",
+      "Created",
+      "Updated",
+      "Status",
+      "Field",
+      "Value",
+      "#",
+      "Log Line",
+    ];
     const testId = "JobsTable";
 
     expectedHeaders.forEach((headerText) => {
@@ -34,30 +43,30 @@ describe("JobsLogTable tests", () => {
       expect(header).toBeInTheDocument();
     });
 
-    expect(screen.getByTestId("JobLogTable-cell-row-0-col-field")).toHaveTextContent(
-      "ID",
-    );
-    expect(screen.getByTestId("JobLogTable-cell-row-0-col-value")).toHaveTextContent(
-      "1",
-    );
-    expect(screen.getByTestId("JobLogTable-cell-row-1-col-field")).toHaveTextContent(
-      "Created",
-    );
-    expect(screen.getByTestId("JobLogTable-cell-row-1-col-value")).toHaveTextContent(
-      "11/13/2022, 7:49:58 PM",
-    );
-    expect(screen.getByTestId("JobLogTable-cell-row-2-col-field")).toHaveTextContent(
-      "Updated",
-    );
-    expect(screen.getByTestId("JobLogTable-cell-row-2-col-value")).toHaveTextContent(
-      "11/13/2022, 7:49:59 PM",
-    );
-    expect(screen.getByTestId("JobLogTable-cell-row-3-col-field")).toHaveTextContent(
-      "Status",
-    );
-    expect(screen.getByTestId("JobLogTable-cell-row-3-col-value")).toHaveTextContent(
-      "complete",
-    );
+    expect(
+      screen.getByTestId("JobLogTable-cell-row-0-col-field"),
+    ).toHaveTextContent("ID");
+    expect(
+      screen.getByTestId("JobLogTable-cell-row-0-col-value"),
+    ).toHaveTextContent("1");
+    expect(
+      screen.getByTestId("JobLogTable-cell-row-1-col-field"),
+    ).toHaveTextContent("Created");
+    expect(
+      screen.getByTestId("JobLogTable-cell-row-1-col-value"),
+    ).toHaveTextContent("11/13/2022, 7:49:58 PM");
+    expect(
+      screen.getByTestId("JobLogTable-cell-row-2-col-field"),
+    ).toHaveTextContent("Updated");
+    expect(
+      screen.getByTestId("JobLogTable-cell-row-2-col-value"),
+    ).toHaveTextContent("11/13/2022, 7:49:59 PM");
+    expect(
+      screen.getByTestId("JobLogTable-cell-row-3-col-field"),
+    ).toHaveTextContent("Status");
+    expect(
+      screen.getByTestId("JobLogTable-cell-row-3-col-value"),
+    ).toHaveTextContent("complete");
 
     expect(
       screen.getByTestId("JobLogTable-cell-row-0-col-index"),
@@ -68,12 +77,11 @@ describe("JobsLogTable tests", () => {
     ).toHaveTextContent("Hello World! from test job");
 
     expect(
-        screen.getByTestId("JobLogTable-cell-row-1-col-index"),
-      ).toHaveTextContent("2");
-  
-      expect(
-        screen.getByTestId("JobLogTable-cell-row-1-col-logLine"),
-      ).toHaveTextContent("Goodbye from test job!");
+      screen.getByTestId("JobLogTable-cell-row-1-col-index"),
+    ).toHaveTextContent("2");
 
+    expect(
+      screen.getByTestId("JobLogTable-cell-row-1-col-logLine"),
+    ).toHaveTextContent("Goodbye from test job!");
   });
 });

--- a/frontend/src/tests/components/Jobs/JobsLogsTable.test.js
+++ b/frontend/src/tests/components/Jobs/JobsLogsTable.test.js
@@ -36,7 +36,6 @@ describe("JobsLogTable tests", () => {
       "#",
       "Log Line",
     ];
-    const testId = "JobsTable";
 
     expectedHeaders.forEach((headerText) => {
       const header = screen.getByText(headerText);

--- a/frontend/src/tests/components/Jobs/JobsLogsTable.test.js
+++ b/frontend/src/tests/components/Jobs/JobsLogsTable.test.js
@@ -7,14 +7,15 @@ import jobsFixtures from "fixtures/jobsFixtures";
 describe("JobsLogTable tests", () => {
   const queryClient = new QueryClient();
 
-  test("renders without crashing for empty table", () => {
+  test("renders without crashing for empty table", async () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <JobsLogTable />
+          <JobsLogTable job={null} />
         </MemoryRouter>
       </QueryClientProvider>,
     );
+    await screen.findByTestId("JobLogTable-not-found");
   });
 
   test("Has the expected column headers and content", () => {
@@ -82,5 +83,71 @@ describe("JobsLogTable tests", () => {
     expect(
       screen.getByTestId("JobLogTable-cell-row-1-col-logLine"),
     ).toHaveTextContent("Goodbye from test job!");
+  });
+
+  test("Has the expected column headers and content", () => {
+    const emptyJob = {
+      id: 1,
+      createdAt: "2022-11-13T19:49:58.097465-08:00",
+      updatedAt: "2022-11-13T19:49:59.203879-08:00",
+      status: "complete",
+      log: "",
+    };
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <JobsLogTable job={emptyJob} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const expectedHeaders = [
+      "ID",
+      "Created",
+      "Updated",
+      "Status",
+      "Field",
+      "Value",
+      "#",
+      "Log Line",
+    ];
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByTestId("JobLogTable-cell-row-0-col-field"),
+    ).toHaveTextContent("ID");
+    expect(
+      screen.getByTestId("JobLogTable-cell-row-0-col-value"),
+    ).toHaveTextContent("1");
+    expect(
+      screen.getByTestId("JobLogTable-cell-row-1-col-field"),
+    ).toHaveTextContent("Created");
+    expect(
+      screen.getByTestId("JobLogTable-cell-row-1-col-value"),
+    ).toHaveTextContent("11/13/2022, 7:49:58 PM");
+    expect(
+      screen.getByTestId("JobLogTable-cell-row-2-col-field"),
+    ).toHaveTextContent("Updated");
+    expect(
+      screen.getByTestId("JobLogTable-cell-row-2-col-value"),
+    ).toHaveTextContent("11/13/2022, 7:49:59 PM");
+    expect(
+      screen.getByTestId("JobLogTable-cell-row-3-col-field"),
+    ).toHaveTextContent("Status");
+    expect(
+      screen.getByTestId("JobLogTable-cell-row-3-col-value"),
+    ).toHaveTextContent("complete");
+
+    expect(
+      screen.queryByTestId("JobLogTable-cell-row-0-col-index"),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByTestId("JobLogTable-cell-row-0-col-logLine"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/pages/Jobs/JobsLogPage.test.js
+++ b/frontend/src/tests/pages/Jobs/JobsLogPage.test.js
@@ -1,0 +1,97 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import { allTheSubjects } from "fixtures/subjectFixtures";
+import userEvent from "@testing-library/user-event";
+
+import JobsLogPage from "main/pages/Jobs/JobsLogPage";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import jobsFixtures from "fixtures/jobsFixtures";
+
+describe("JobsLogPage tests", () => {
+  const queryClient = new QueryClient();
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  beforeEach(() => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.adminUser);
+    axiosMock.onGet("/api/jobs/all").reply(200, jobsFixtures.sixJobs);
+    axiosMock.onGet("/api/UCSBSubjects/all").reply(200, allTheSubjects);
+  });
+
+  const mockJob = {
+    id: "123",
+    createdAt: "2022-11-13T19:49:59",
+    updatedAt: "2022-11-13T20:49:59",
+    status: "complete",
+    log: "Log line 1\nLog line 2\nLog line 3",
+  };
+
+  test("renders without crashing", async () => {
+    axiosMock.onGet("/api/jobs/all").reply(200, [mockJob]);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={["/admin/jobs/logs/123"]}>
+          <Routes>
+            <Route path="/admin/jobs/logs/:id" element={<JobsLogPage />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText("Job Log")).toBeInTheDocument();
+    expect(await screen.findByText("ID")).toBeInTheDocument();
+    expect(await screen.findByText("123")).toBeInTheDocument();
+  });
+
+  test("renders job details correctly", async () => {
+    axiosMock.onGet("/api/jobs/all").reply(200, [mockJob]);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={["/admin/jobs/logs/123"]}>
+          <Routes>
+            <Route path="/admin/jobs/logs/:id" element={<JobsLogPage />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText("123")).toBeInTheDocument(); // Job ID
+    expect(await screen.findByText("complete")).toBeInTheDocument(); // Status
+    expect(
+      await screen.findByText("11/13/2022, 7:49:59 PM"),
+    ).toBeInTheDocument(); // CreatedAt
+    expect(
+      await screen.findByText("11/13/2022, 8:49:59 PM"),
+    ).toBeInTheDocument(); // UpdatedAt
+  });
+
+  test("renders the log lines correctly", async () => {
+    axiosMock.onGet("/api/jobs/all").reply(200, [mockJob]);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={["/admin/jobs/logs/123"]}>
+          <Routes>
+            <Route path="/admin/jobs/logs/:id" element={<JobsLogPage />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText("Log line 1")).toBeInTheDocument();
+    expect(await screen.findByText("Log line 2")).toBeInTheDocument();
+    expect(await screen.findByText("Log line 3")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/pages/Jobs/JobsLogPage.test.js
+++ b/frontend/src/tests/pages/Jobs/JobsLogPage.test.js
@@ -1,10 +1,9 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 import { allTheSubjects } from "fixtures/subjectFixtures";
-import userEvent from "@testing-library/user-event";
 
 import JobsLogPage from "main/pages/Jobs/JobsLogPage";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";

--- a/frontend/src/tests/pages/Jobs/JobsLogPage.test.js
+++ b/frontend/src/tests/pages/Jobs/JobsLogPage.test.js
@@ -93,4 +93,20 @@ describe("JobsLogPage tests", () => {
     expect(await screen.findByText("Log line 2")).toBeInTheDocument();
     expect(await screen.findByText("Log line 3")).toBeInTheDocument();
   });
+
+  test("renders invalid job correctly", async () => {
+    axiosMock.onGet("/api/jobs/all").reply(200, [mockJob]);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={["/admin/jobs/logs/999"]}>
+          <Routes>
+            <Route path="/admin/jobs/logs/:id" element={<JobsLogPage />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText("Job not found.")).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
- Closes #26 
- Added `JobsLogTable` component which shows a detailed view for a particular job. Shows the full Job Log
- Added `JobsLogPage` page which displays the `JobsLogTable` for a long running job
- Added route in `App.js` which routes `/admin/jobs/logs/:id` to the `JobsLogPage` for the respective long running job 
- Dokku Deployment: https://courses-sameer.dokku-03.cs.ucsb.edu/