### PR TITLE
Add Link to Detailed Log Page

### DIFF
--- a/frontend/src/main/components/Jobs/JobsTable.js
+++ b/frontend/src/main/components/Jobs/JobsTable.js
@@ -1,8 +1,8 @@
 import React from "react";
 import OurTable, {
-  PlaintextColumn,
   DateColumn,
 } from "main/components/OurTable";
+import { Link } from "react-router-dom";
 
 export default function JobsTable({ jobs }) {
   const testid = "JobsTable";
@@ -26,7 +26,25 @@ export default function JobsTable({ jobs }) {
       Header: "Status",
       accessor: "status",
     },
-    PlaintextColumn("Log", (cell) => truncateLog(cell.row.original.log)),
+    {
+      Header: "Log",
+      id: "log",
+      Cell: ({cell}) => {
+        const log = cell.row.original.log;
+        const id = cell.row.original.id;
+        const truncatedLog = truncateLog(log);
+        return (
+          <div>
+            <pre>{truncatedLog}</pre>
+            {log.split("\n").length > 10 && (
+              <Link to={`/admin/jobs/logs/${id}`} date-testid={`${testid}-see-entire-log-${id}`}>
+                [See entire log]
+              </Link>
+            )}
+          </div>
+        );
+      }
+    }
   ];
 
   const sortees = React.useMemo(

--- a/frontend/src/main/components/Jobs/JobsTable.js
+++ b/frontend/src/main/components/Jobs/JobsTable.js
@@ -31,7 +31,7 @@ export default function JobsTable({ jobs }) {
     },
     {
       Header: "Log",
-      id: "log",
+      id: "Log",
       Cell: ({ cell }) => {
         const log = cell.row.original.log;
         const id = cell.row.original.id;
@@ -39,7 +39,7 @@ export default function JobsTable({ jobs }) {
         return (
           <div>
             <pre>{truncatedLog}</pre>
-            {log.split("\n").length > 10 && (
+            {log && log.split("\n").length > 10 && (
               <div>
                 <pre>...</pre>
                 <Link

--- a/frontend/src/main/components/Jobs/JobsTable.js
+++ b/frontend/src/main/components/Jobs/JobsTable.js
@@ -1,7 +1,5 @@
 import React from "react";
-import OurTable, {
-  DateColumn,
-} from "main/components/OurTable";
+import OurTable, { DateColumn } from "main/components/OurTable";
 import { Link } from "react-router-dom";
 
 export default function JobsTable({ jobs }) {
@@ -26,7 +24,7 @@ export default function JobsTable({ jobs }) {
     {
       Header: "Log",
       id: "log",
-      Cell: ({cell}) => {
+      Cell: ({ cell }) => {
         const log = cell.row.original.log;
         const id = cell.row.original.id;
         const truncatedLog = truncateLog(log);
@@ -34,14 +32,20 @@ export default function JobsTable({ jobs }) {
           <div>
             <pre>{truncatedLog}</pre>
             {log.split("\n").length > 10 && (
-              <Link to={`/admin/jobs/logs/${id}`} date-testid={`${testid}-see-entire-log-${id}`}>
-                [See entire log]
-              </Link>
+              <div>
+                <pre>...</pre>
+                <Link
+                  to={`/admin/jobs/logs/${id}`}
+                  date-testid={`${testid}-see-entire-log-${id}`}
+                >
+                  [See entire log]
+                </Link>
+              </div>
             )}
           </div>
         );
-      }
-    }
+      },
+    },
   ];
 
   const sortees = React.useMemo(

--- a/frontend/src/main/components/Jobs/JobsTable.js
+++ b/frontend/src/main/components/Jobs/JobsTable.js
@@ -30,7 +30,6 @@ export default function JobsTable({ jobs }) {
     },
     {
       Header: "Log",
-      id: "Log",
       Cell: ({ cell }) => {
         const log = cell.row.original.log;
         const id = cell.row.original.id;
@@ -43,7 +42,7 @@ export default function JobsTable({ jobs }) {
                 <pre>...</pre>
                 <Link
                   to={`/admin/jobs/logs/${id}`}
-                  date-testid={`${testid}-see-entire-log-${id}`}
+                  data-testid={`${testid}-see-entire-log-${id}`}
                 >
                   [See entire log]
                 </Link>

--- a/frontend/src/tests/components/Jobs/JobsTable.test.js
+++ b/frontend/src/tests/components/Jobs/JobsTable.test.js
@@ -80,6 +80,10 @@ describe("JobsTable tests", () => {
     const expectedLog =
       Array(10).fill("Log").join("\n") + "...[See entire log]";
     expect(logCell.textContent).toBe(expectedLog);
+    const link = screen.getByText("[See entire log]");
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "/admin/jobs/logs/1");
+    expect(link).toHaveAttribute("data-testid", "JobsTable-see-entire-log-1");
   });
 
   test("Does not truncate logs 10 lines or shorter", () => {

--- a/frontend/src/tests/components/Jobs/JobsTable.test.js
+++ b/frontend/src/tests/components/Jobs/JobsTable.test.js
@@ -48,7 +48,7 @@ describe("JobsTable tests", () => {
     ).toHaveTextContent("complete");
     expect(
       screen.getByTestId(`${testId}-cell-row-0-col-Log`),
-    ).toHaveTextContent("Hello World! from test job!Goodbye from test job!");
+    ).toHaveTextContent("Hello World! from test job! Goodbye from test job!");
 
     expect(
       screen.getByTestId(`JobsTable-header-id-sort-carets`),
@@ -76,7 +76,7 @@ describe("JobsTable tests", () => {
     const testId = "JobsTable";
     const logCell = screen.getByTestId(`${testId}-cell-row-0-col-Log`);
 
-    const expectedLog = Array(10).fill("Log").join(""); // Remove \n to match flattened DOM output
+    const expectedLog = Array(10).fill("Log").join("\n") + "...[See entire log]"; 
     expect(logCell.textContent).toBe(expectedLog);
   });
 
@@ -102,7 +102,7 @@ describe("JobsTable tests", () => {
     const testId = "JobsTable";
     const logCell = screen.getByTestId(`${testId}-cell-row-0-col-Log`);
 
-    const expectedLog = Array(10).fill("Log").join(""); // Remove \n to match flattened DOM output
+    const expectedLog = Array(10).fill("Log").join("\n"); 
     expect(logCell.textContent).toBe(expectedLog);
   });
 

--- a/frontend/src/tests/components/Jobs/JobsTable.test.js
+++ b/frontend/src/tests/components/Jobs/JobsTable.test.js
@@ -27,16 +27,10 @@ describe("JobsTable tests", () => {
     );
 
     const expectedHeaders = ["id", "Created", "Updated", "Status", "Log"];
-    const expectedFields = ["id", "Created", "Updated", "status", "Log"];
     const testId = "JobsTable";
 
     expectedHeaders.forEach((headerText) => {
       const header = screen.getByText(headerText);
-      expect(header).toBeInTheDocument();
-    });
-
-    expectedFields.forEach((field) => {
-      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
       expect(header).toBeInTheDocument();
     });
 

--- a/frontend/src/tests/components/Jobs/JobsTable.test.js
+++ b/frontend/src/tests/components/Jobs/JobsTable.test.js
@@ -76,7 +76,8 @@ describe("JobsTable tests", () => {
     const testId = "JobsTable";
     const logCell = screen.getByTestId(`${testId}-cell-row-0-col-Log`);
 
-    const expectedLog = Array(10).fill("Log").join("\n") + "...[See entire log]"; 
+    const expectedLog =
+      Array(10).fill("Log").join("\n") + "...[See entire log]";
     expect(logCell.textContent).toBe(expectedLog);
   });
 
@@ -102,7 +103,7 @@ describe("JobsTable tests", () => {
     const testId = "JobsTable";
     const logCell = screen.getByTestId(`${testId}-cell-row-0-col-Log`);
 
-    const expectedLog = Array(10).fill("Log").join("\n"); 
+    const expectedLog = Array(10).fill("Log").join("\n");
     expect(logCell.textContent).toBe(expectedLog);
   });
 

--- a/frontend/src/tests/pages/AdminJobsPage.test.js
+++ b/frontend/src/tests/pages/AdminJobsPage.test.js
@@ -59,7 +59,7 @@ describe("AdminJobsPage tests", () => {
     ).toHaveTextContent("complete");
     expect(
       screen.getByTestId(`${testId}-cell-row-0-col-Log`),
-    ).toHaveTextContent("Hello World! from test job!Goodbye from test job!");
+    ).toHaveTextContent("Hello World! from test job! Goodbye from test job!");
   });
 
   test("user can submit a test job", async () => {


### PR DESCRIPTION
- Closes #30 
- Added a hyperlink [See entire log] in the "Log" column of the `JobsTable` which navigates to `/admin/jobs/logs/:id`
- Displayed the hyperlink conditionally for logs exceeding 10 lines.
- Changed the "Log" column from a plaintext column to a custom column with a Cell function to render the truncated log and the hyperlink.
- Dokku Link: https://courses-sameer-1.dokku-03.cs.ucsb.edu/