### PR TITLE
Makes Description Optional on Personal Schedule, attempt 2

### DIFF
--- a/frontend/src/main/components/PersonalSchedules/PersonalScheduleForm.js
+++ b/frontend/src/main/components/PersonalSchedules/PersonalScheduleForm.js
@@ -84,10 +84,7 @@ function PersonalScheduleForm({
           data-testid="PersonalScheduleForm-description"
           id="description"
           type="text"
-          isInvalid={Boolean(errors.description)}
-          {...register("description", {
-            required: "Description is required.",
-          })}
+          {...register("description")}
         />
         <Form.Control.Feedback type="invalid">
           {errors.description?.message}

--- a/frontend/src/tests/components/PersonalSchedules/PersonalScheduleForm.test.js
+++ b/frontend/src/tests/components/PersonalSchedules/PersonalScheduleForm.test.js
@@ -81,7 +81,6 @@ describe("PersonalScheduleForm tests", () => {
     fireEvent.click(submitButton);
 
     expect(await screen.findByText(/Name is required./)).toBeInTheDocument();
-    expect(screen.getByText(/Description is required./)).toBeInTheDocument();
   });
 
   test("No Error messages on good input", async () => {


### PR DESCRIPTION
Closes #8 


# Before commit:
## When creating personal schedule without description:
<img width="1360" alt="Screenshot 2024-11-16 at 3 43 06 AM" src="https://github.com/user-attachments/assets/86ec9f42-ee0c-4923-a84a-20a89ef90111">

## When editing personal schedule to clear out description:
<img width="1373" alt="Screenshot 2024-11-16 at 3 43 49 AM" src="https://github.com/user-attachments/assets/ca57a93e-031f-43c4-8412-bc938748a1ba">

# After commit:
## When creating personal schedule without description:
<img width="1285" alt="Screenshot 2024-11-16 at 3 48 51 AM" src="https://github.com/user-attachments/assets/4a701a27-8d75-4baf-91f0-69c0bf4bc3c1">
*Clicks Create Button*
<img width="1306" alt="Screenshot 2024-11-16 at 3 49 09 AM" src="https://github.com/user-attachments/assets/c17f1a5a-1eae-427e-b34b-18213ff36bca">

## When editing personal schedule to clear out description:
<img width="1257" alt="Screenshot 2024-11-16 at 3 50 09 AM" src="https://github.com/user-attachments/assets/085039d0-45f6-4385-b416-e91887835dc1">
*Clicks Edit button*
<img width="1305" alt="Screenshot 2024-11-16 at 3 50 28 AM" src="https://github.com/user-attachments/assets/35d9058e-2fae-4f91-92bb-9b2770d828d7">
*Clicks Update Button*
<img width="1268" alt="Screenshot 2024-11-16 at 3 50 53 AM" src="https://github.com/user-attachments/assets/132b6f5d-d8c6-455f-b6ba-b28549d55c12">




# Dokku Link: [https://courses-bsaiju.dokku-03.cs.ucsb.edu/](https://courses-bsaiju.dokku-03.cs.ucsb.edu/)