### PR TITLE
Fixed a Stryker Exception in SectionsOverTimeTable.js

### DIFF
--- a/frontend/src/main/components/Sections/SectionsOverTimeTable.js
+++ b/frontend/src/main/components/Sections/SectionsOverTimeTable.js
@@ -41,7 +41,6 @@ export default function SectionsOverTimeTable({ sections }) {
       aggregate: getCourseId,
       Aggregated: ({ cell: { value } }) => `${value}`,
 
-      // Stryker disable next-line ArrowFunction: factor out and test the arrow function separately
       Cell: ({ cell: { value } }) => value.substring(0, value.length - 2),
     },
     {

--- a/frontend/src/tests/components/Sections/SectionsOverTimeTable.test.js
+++ b/frontend/src/tests/components/Sections/SectionsOverTimeTable.test.js
@@ -309,4 +309,37 @@ describe("Section tests", () => {
         .querySelector('a[href$="/coursedetails/20221/12625"]'),
     ).toBeInTheDocument();
   });
+
+  test("Course ID's are correct", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <SectionsOverTimeTable sections={fiveSections} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+
+    );
+    const testId = "SectionsOverTimeTable";
+
+    const expandRow = screen.getByTestId(
+      `${testId}-cell-row-1-col-quarter-expand-symbols`,
+    );
+    fireEvent.click(expandRow);
+
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-courseInfo.courseId`),
+    ).toHaveTextContent("ECE 5");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-courseInfo.courseId`),
+    ).toHaveTextContent("ECE 5");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-2-col-courseInfo.courseId`),
+    ).toHaveTextContent("ECE 5");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-3-col-courseInfo.courseId`),
+    ).toHaveTextContent("ECE 5");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-4-col-courseInfo.courseId`),
+    ).toHaveTextContent("ECE 5");
+  });
 });


### PR DESCRIPTION
Closes #18 

No longer run into a Stryker Error in SectionsOverTimeTable when running `npm stryker run`. Fixed by adding a test in SectionsOverTimeTable.test.js.

# Running Stryker before edits
<img width="1278" alt="Screenshot 2024-11-25 at 7 03 58 AM" src="https://github.com/user-attachments/assets/34b4cdc2-dc0b-4750-b2e5-6aa793864e63">

# Running Stryker after edits
<img width="1281" alt="Screenshot 2024-11-25 at 7 09 46 AM" src="https://github.com/user-attachments/assets/f4ea9ee7-ac23-4451-ac4a-b52c34343593">

