### PR TITLE
DropdownSelector Component for Quarters and Subjects

### DIFF
--- a/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
+++ b/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
@@ -20,6 +20,7 @@ function SingleQuarterDropdown({
   controlId,
   onChange = null,
   label = "Quarter",
+  showAll = false,
 }) {
   const lastInd = quarters.length - 1;
 
@@ -31,7 +32,9 @@ function SingleQuarterDropdown({
 
   const [quarterState, setQuarterState] = useState(
     // Stryker disable next-line all : not sure how to test/mock local storage
-    quarter.yyyyq || localSearchQuarter || quarters[lastInd].yyyyq,
+    showAll
+      ? "ALL"
+      : quarter?.yyyyq || localSearchQuarter || quarters[lastInd]?.yyyyq,
   );
 
   const handleQuarterOnChange = (event) => {
@@ -53,6 +56,11 @@ function SingleQuarterDropdown({
         value={quarterState}
         onChange={handleQuarterOnChange}
       >
+        {showAll && (
+          <option data-testid={`${controlId}-option-all`} value="ALL">
+            ALL
+          </option>
+        )}
         {quarters.map(function (object, i) {
           const key = `${controlId}-option-${i}`;
           return (

--- a/frontend/src/main/components/Subjects/SingleSubjectDropdown.js
+++ b/frontend/src/main/components/Subjects/SingleSubjectDropdown.js
@@ -9,6 +9,7 @@ const SingleSubjectDropdown = ({
   controlId,
   onChange = null,
   label = "Subject Area",
+  showAll = false,
 }) => {
   const localSearchSubject = localStorage.getItem(controlId);
 
@@ -36,6 +37,11 @@ const SingleSubjectDropdown = ({
         value={subjectState}
         onChange={handleSubjectOnChange}
       >
+        {showAll && (
+          <option data-testid={`${controlId}-option-all`} value="ALL">
+            ALL
+          </option>
+        )}
         {subjects.map(function (object) {
           const subjectCode = object.subjectCode.replace(/ /g, "-");
           const key = `${controlId}-option-${subjectCode}`;

--- a/frontend/src/stories/components/Quarters/SingleQuarterDropdown.stories.js
+++ b/frontend/src/stories/components/Quarters/SingleQuarterDropdown.stories.js
@@ -37,3 +37,21 @@ export const ManyQuarters = Template.bind({});
 ManyQuarters.args = {
   quarters: quarterRange("20081", "20213"),
 };
+
+export const OneQuarterShowAll = Template.bind({});
+OneQuarterShowAll.args = {
+  quarters: quarterRange("20211", "20211"),
+  showAll: true,
+};
+
+export const ThreeQuartersShowAll = Template.bind({});
+ThreeQuartersShowAll.args = {
+  quarters: quarterRange("20204", "20212"),
+  showAll: true,
+};
+
+export const ManyQuartersShowAll = Template.bind({});
+ManyQuartersShowAll.args = {
+  quarters: quarterRange("20081", "20213"),
+  showAll: true,
+};

--- a/frontend/src/stories/components/Subjects/SingleSubjectDropdown.stories.js
+++ b/frontend/src/stories/components/Subjects/SingleSubjectDropdown.stories.js
@@ -40,3 +40,21 @@ export const AllTheSubjects = Template.bind({});
 AllTheSubjects.args = {
   subjects: allTheSubjects,
 };
+
+export const OneSubjectShowAll = Template.bind({});
+OneSubjectShowAll.args = {
+  subjects: oneSubject,
+  showAll: true,
+};
+
+export const ThreeSubjectsShowAll = Template.bind({});
+ThreeSubjectsShowAll.args = {
+  subjects: threeSubjects,
+  showAll: true,
+};
+
+export const AllTheSubjectsShowAll = Template.bind({});
+AllTheSubjectsShowAll.args = {
+  subjects: allTheSubjects,
+  showAll: true,
+};

--- a/frontend/src/tests/components/Quarters/SingleQuarterDropdown.test.js
+++ b/frontend/src/tests/components/Quarters/SingleQuarterDropdown.test.js
@@ -44,6 +44,18 @@ describe("SingleQuarterSelector tests", () => {
     );
   });
 
+  test("renders without crashing on all quarters", () => {
+    render(
+      <SingleQuarterDropdown
+        quarters={quarterRange("20214", "20222")}
+        quarter={quarter}
+        setQuarter={setQuarter}
+        controlId="sqd1"
+        showAll={true}
+      />,
+    );
+  });
+
   test("when I select an object, the value changes", async () => {
     render(
       <SingleQuarterDropdown

--- a/frontend/src/tests/components/Subjects/SingleSubjectDropdown.test.js
+++ b/frontend/src/tests/components/Subjects/SingleSubjectDropdown.test.js
@@ -75,6 +75,18 @@ describe("SingleSubjectDropdown tests", () => {
     }
   });
 
+  test("renders without crashing on all subjects", () => {
+    render(
+      <SingleSubjectDropdown
+        subjects={threeSubjects}
+        subject={subject}
+        setSubject={setSubject}
+        controlId="ssd1"
+        showAll={true}
+      />,
+    );
+  });
+
   test("sorts and puts hyphens in testids", () => {
     render(
       <SingleSubjectDropdown


### PR DESCRIPTION
Adds a component for users to select ALL for quarters and subjects. Closes #33.

<img width="1703" alt="Screenshot 2024-11-26 at 8 49 20 AM" src="https://github.com/user-attachments/assets/a87eea8d-8a1d-4633-8aa0-8b3340bd0991">

Image above shows the new option in the dropdown when selecting quarters.
Storybook: 